### PR TITLE
fix(macos): OCR SIGKILL 강제종료 해결 — entitlements 추가 (v2.6.7)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -245,13 +245,28 @@ jobs:
         run: pnpm exec tauri build --target aarch64-apple-darwin
 
       # tauri.macos.conf.json 의 signingIdentity:"-" 가 ad-hoc 서명을 적용하지만,
-      # 일부 Tauri 버전에선 누락될 수 있어 명시적 재서명으로 보강.
-      - name: Re-apply ad-hoc signature
+      # 일부 Tauri 버전에선 entitlements 가 누락될 수 있어 명시적 재서명으로 보강.
+      # ORT(onnxruntime) dylib 동적 로드 시 macOS Library Validation 이 SIGKILL 보내는
+      # 이슈 해결 — entitlements.plist 의 disable-library-validation 권한이 핵심.
+      # inside-out signing: 번들 dylib → 메인 바이너리 → .app 번들 순서.
+      - name: Re-apply ad-hoc signature with entitlements
         run: |
           APP="src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Anything.app"
+          ENTITLEMENTS="src-tauri/entitlements.plist"
           if [ -d "$APP" ]; then
-            codesign --force --deep --sign - "$APP"
-            codesign -dv "$APP" 2>&1 | head -5 || true
+            # 1) 번들된 외부 dylib (libonnxruntime.dylib 등) 먼저 서명
+            find "$APP/Contents/Resources" -name "*.dylib" -print0 2>/dev/null \
+              | xargs -0 -I{} codesign --force --options runtime --sign - "{}"
+            # 2) 메인 실행 바이너리에 entitlements + hardened runtime 적용
+            codesign --force --options runtime \
+              --entitlements "$ENTITLEMENTS" \
+              --sign - "$APP/Contents/MacOS/docufinder" || true
+            # 3) .app 번들 전체 deep 재서명 (entitlements 유지)
+            codesign --force --deep --options runtime \
+              --entitlements "$ENTITLEMENTS" \
+              --sign - "$APP"
+            # 검증 로그
+            codesign -dv --entitlements - "$APP" 2>&1 | head -20 || true
           fi
 
       - name: Upload dmg to release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [2.6.7] - 2026-05-17
+
+**macOS 핫픽스 — OCR 활성화 시 SIGKILL 강제종료 해결 (entitlements 추가)**
+
+### 배경
+- macOS 사용자분이 OCR 옵션 켜고 인덱싱 시작하면 앱이 강제종료되고, 재설치해도 동일 증상 → `~/Library/Application Support`, `~/Library/Caches` 등 잔존 파일 수동 삭제 후에야 복구된다는 상세한 리포트 + 임시 우회법까지 보내주심 (감사합니다).
+- 원인: PaddleOCR 구동을 위해 `ort` 크레이트가 번들된 `libonnxruntime.dylib` 를 `dlopen` 하는 시점에 macOS **Library Validation** 이 서명 불일치(ad-hoc 서명 + 외부 dylib 로드) 를 보안 위협으로 판단하여 `SIGKILL` 송출.
+- 코드 확인: `src-tauri/tauri.macos.conf.json` 에 `signingIdentity: "-"` + `entitlements: null` 상태였음. ORT 가 동적 로드 방식(`ort = { default-features = false }`) 으로 `resources/onnxruntime/libonnxruntime.dylib` 번들 사용 → entitlements 부재 시 dyld 단계에서 차단.
+
+### 변경
+- **`src-tauri/entitlements.plist` 신규** — 다음 3개 권한 부여:
+  - `com.apple.security.cs.disable-library-validation` (외부 dylib 로드 허용 — 핵심)
+  - `com.apple.security.cs.allow-unsigned-executable-memory` (ONNX 런타임 JIT 영역 허용)
+  - `com.apple.security.cs.allow-dyld-environment-variables` (dyld 환경변수 허용 — ONNX 일부 경로 탐색용)
+- **`src-tauri/tauri.macos.conf.json`** — `entitlements: "entitlements.plist"` 로 연결.
+- **`.github/workflows/publish.yml`** — macOS 빌드의 ad-hoc 재서명 단계를 inside-out signing 으로 강화:
+  1. 번들된 외부 `.dylib` 들 (`libonnxruntime.dylib` 등) 먼저 `codesign --options runtime` 으로 개별 서명
+  2. 메인 실행 바이너리(`Contents/MacOS/docufinder`) 에 `--entitlements entitlements.plist --options runtime` 적용
+  3. `.app` 번들 전체 `--deep --entitlements ... --options runtime` 재서명
+  4. 검증 로그(`codesign -dv --entitlements -`) 출력
+
+이전 단계는 단순 `codesign --force --deep --sign -` 만 호출하여 Tauri 빌드 시 적용된 entitlements 가 덮어쓰기 되며 사라지는 문제가 있었음.
+
+### 사용자 안내
+- **v2.6.6 이하 macOS 사용자분** — 동일 증상 겪고 계시면 v2.6.7 dmg 재설치. 재설치 전 잔존 파일 삭제 권장:
+  ```bash
+  rm -rf ~/Library/Application\ Support/com.anything.app
+  rm -rf ~/Library/Caches/com.anything.app
+  rm -rf ~/Library/Logs/com.anything.app
+  rm -f  ~/Library/Preferences/com.anything.app.plist
+  ```
+  (실제 bundle id 가 다를 수 있으니 위 경로에서 `com.anything.app` 부분 확인 후 삭제)
+- 임시 우회가 필요하면 설치된 앱에 직접 entitlements 주입도 가능 (사용자분이 보내주신 방법):
+  ```bash
+  sudo codesign --force --options runtime \
+    --entitlements src-tauri/entitlements.plist --sign - \
+    /Applications/Anything.app/Contents/MacOS/docufinder
+  sudo codesign --force --options runtime \
+    --entitlements src-tauri/entitlements.plist --sign - \
+    /Applications/Anything.app
+  ```
+
 ## [2.6.6] - 2026-05-16
 
 **LTSC 환경 핫픽스 — Tauri fixedRuntime 모드가 wry 에 path 전달 안 한다는 사실 확인 후 with_environment inject 활성화 (이슈 #24)**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anything",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "description": "로컬 문서 검색 앱 - Everything 대항마",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "docufinder"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docufinder"
-version = "2.6.6"
+version = "2.6.7"
 description = "로컬 문서 검색 앱 - HWPX, Office, PDF 지원"
 authors = ["Chris"]
 edition = "2021"

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Anything",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "identifier": "com.anything.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -15,7 +15,7 @@
     "macOS": {
       "minimumSystemVersion": "11.0",
       "signingIdentity": "-",
-      "entitlements": null,
+      "entitlements": "entitlements.plist",
       "exceptionDomain": null
     }
   },


### PR DESCRIPTION
## 배경

macOS 사용자분이 OCR 옵션 켜고 인덱싱 시작 시 앱이 강제종료되고, 재설치해도 동일 증상 → `~/Library/Application Support`, `~/Library/Caches` 등 잔존 파일을 수동 삭제해야 복구된다는 상세한 리포트를 메일로 보내주심. 진단 + PoC 우회 스크립트까지 동봉되어 원인 특정 즉시 가능했음.

## 원인

PaddleOCR 구동을 위해 `ort` 크레이트가 번들된 `libonnxruntime.dylib` 를 `dlopen` 하는 시점, macOS **Library Validation** 이 ad-hoc 서명 + 외부 dylib 로드를 보안 위협으로 판단하여 `SIGKILL` 송출.

코드 상태 확인:
- `src-tauri/tauri.macos.conf.json`: `signingIdentity: "-"` + `entitlements: null`
- `Cargo.toml`: `ort = { default-features = false, ... }` (동적 로드 방식)
- `tauri.macos.conf.json#resources`: `libonnxruntime.dylib` 번들

→ entitlements 부재로 dyld 차단 → SIGKILL.

## 변경 사항

### 1) `src-tauri/entitlements.plist` 신규
```xml
<key>com.apple.security.cs.disable-library-validation</key>  <true/>
<key>com.apple.security.cs.allow-unsigned-executable-memory</key>  <true/>
<key>com.apple.security.cs.allow-dyld-environment-variables</key>  <true/>
```

### 2) `tauri.macos.conf.json`
- `entitlements: null` → `entitlements: "entitlements.plist"`

### 3) `.github/workflows/publish.yml` — Re-apply 단계 강화
**기존**: 단순 `codesign --force --deep --sign -` → Tauri 빌드가 적용한 entitlements 가 deep 재서명에서 사라질 위험.

**변경**: inside-out signing
1. 번들 dylib (`libonnxruntime.dylib` 등) `codesign --options runtime --sign -` 으로 개별 서명
2. 메인 실행 바이너리에 `--entitlements entitlements.plist --options runtime` 적용
3. `.app` 번들 전체 `--deep --entitlements ... --options runtime` 재서명
4. `codesign -dv --entitlements -` 검증 로그 출력

### 4) 버전 2.6.6 → 2.6.7
- `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`

## 검증 필요

- [ ] `pnpm tauri build --target aarch64-apple-darwin` 로컬 빌드 통과
- [ ] 빌드된 `.app` 에 `codesign -dv --entitlements -` 결과로 entitlements 3개 모두 노출되는지 확인
- [ ] OCR 옵션 켜고 인덱싱 → SIGKILL 재현 안 되는지 확인
- [ ] (가능하면) 메일 보내주신 사용자분께 dmg 미리 전달 / 빠른 검증 부탁

## 잔존 파일 클린업 (별도 후속 작업)

이번 PR 범위 밖이지만, 재설치 후에도 SIGKILL 루프가 도는 패턴은 SQLite WAL / 모델 캐시 손상이 원인일 가능성. 후속 PR 후보:
- 앱 시작 시 DB 무결성 자가 점검 + 손상 시 자동 재생성
- 설정 화면에 "완전 초기화" 메뉴 (잔존 파일 일괄 삭제)
- README 에 수동 클린업 경로 안내 (`~/Library/Application Support/com.anything.app` 외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)