### PR TITLE
chore: prod review 1차 — CI gate + telemetry opt-in + PATH hijack 방지

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Reusable workflow — publish.yml 의 release pipeline 이 tag push 시 호출.
+  # tag 빌드 전에 main 의 검증이 미실행/실패한 코드가 release 되지 않도록 gate.
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Release gate — tag push 시 CI(tsc/cargo fmt/check/clippy/test) 를 먼저 통과시킨다.
+  # ci.yml 을 workflow_call reuse 하므로 검증 본문은 한 곳에서 관리.
+  validate:
+    name: CI gate
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
+
   publish-tauri:
     name: Build & Release (Windows)
+    needs: validate
     permissions:
       contents: write
     runs-on: windows-latest
@@ -193,6 +202,7 @@ jobs:
 
   publish-macos:
     name: Build & Release (macOS arm64)
+    needs: validate
     permissions:
       contents: write
     runs-on: macos-14  # Apple Silicon runner

--- a/src-tauri/src/commands/file.rs
+++ b/src-tauri/src/commands/file.rs
@@ -6,11 +6,19 @@ use tauri::{AppHandle, Manager, State};
 
 use crate::AppContainer;
 
+/// Windows 시스템 실행파일 절대경로 — PATH hijack 방지.
+/// `SystemRoot` 환경변수(기본 `C:\Windows`) 하위 System32 의 풀패스를 반환.
+#[cfg(target_os = "windows")]
+fn windows_system32(exe: &str) -> std::path::PathBuf {
+    let root = std::env::var("SystemRoot").unwrap_or_else(|_| String::from("C:\\Windows"));
+    std::path::PathBuf::from(root).join("System32").join(exe)
+}
+
 /// 플랫폼별 기본 앱으로 경로 열기 (공통 헬퍼)
 fn open_with_default(path_str: &str) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
-        Command::new("explorer")
+        Command::new(windows_system32("explorer.exe"))
             .arg(path_str)
             .spawn()
             .map_err(|e| format!("열기 실패: {}", e))?;
@@ -145,9 +153,14 @@ pub async fn open_file(
                 }
             }
 
-            // 2) PATH 환경변수에서 검색 (비표준 설치 위치 대응)
+            // 2) PATH 환경변수에서 검색 (비표준 설치 위치 대응).
+            // where.exe 자체는 System32 풀패스 사용 (PATH hijack 방지).
+            // 결과(SumatraPDF.exe 위치)는 사용자 PATH 의존 — 정상 사용 케이스.
             if sumatra_exe.is_none() {
-                if let Ok(output) = Command::new("where").arg("SumatraPDF.exe").output() {
+                if let Ok(output) = Command::new(windows_system32("where.exe"))
+                    .arg("SumatraPDF.exe")
+                    .output()
+                {
                     if output.status.success() {
                         if let Some(path) = String::from_utf8_lossy(&output.stdout).lines().next() {
                             let path = path.trim();
@@ -239,8 +252,9 @@ pub async fn open_url(url: String) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
         // cmd /C start는 URL 내 &를 명령 구분자로 해석할 수 있으므로
-        // rundll32로 직접 URL 프로토콜 핸들러 호출 (cmd 인젝션 방지)
-        Command::new("rundll32")
+        // rundll32로 직접 URL 프로토콜 핸들러 호출 (cmd 인젝션 방지).
+        // System32 풀패스 사용으로 PATH hijack 방지.
+        Command::new(windows_system32("rundll32.exe"))
             .args(["url.dll,FileProtocolHandler", &url])
             .spawn()
             .map_err(|e| format!("URL 열기 실패: {}", e))?;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -152,7 +152,9 @@ fn default_ai_max_tokens() -> u32 {
 }
 
 fn default_error_reporting_enabled() -> bool {
-    true
+    // 프라이버시 기본값: opt-out → opt-in 전환 (prod review 2026-05-17).
+    // 사용자가 설정에서 명시적으로 켜기 전까지 외부 전송 없음.
+    false
 }
 
 /// LLM provider 선택.
@@ -339,7 +341,12 @@ fn restrict_file_to_owner(path: &Path) {
     };
 
     let grant = format!(r#"{}:F"#, username);
-    let result = Command::new("icacls")
+    // System32 풀패스 사용으로 PATH hijack 방지.
+    let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| String::from("C:\\Windows"));
+    let icacls = std::path::PathBuf::from(system_root)
+        .join("System32")
+        .join("icacls.exe");
+    let result = Command::new(icacls)
         .arg(path)
         .args(["/inheritance:r", "/grant:r", &grant])
         .creation_flags(CREATE_NO_WINDOW)

--- a/src-tauri/src/commands/telemetry.rs
+++ b/src-tauri/src/commands/telemetry.rs
@@ -12,7 +12,13 @@
 //! 토큰 노출 리스크:
 //!   - 바이너리에서 strings 로 추출 가능. 악용 시 BotFather 로 revoke + 새 토큰으로 재빌드.
 
+use std::path::PathBuf;
+use std::sync::RwLock;
+
 use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::AppContainer;
 
 const TELEGRAM_BOT_TOKEN: &str = match option_env!("TELEGRAM_BOT_TOKEN") {
     Some(t) => t,
@@ -73,10 +79,21 @@ fn send_to_telegram(text: &str) -> Result<(), String> {
     }
 }
 
-/// 프론트엔드 호출: error_reporting_enabled 체크는 프론트에서 해야 함.
-/// Rust panic hook 에서도 직접 호출 가능 (sync).
+/// 프론트엔드 호출: 백엔드에서도 사용자 설정을 재확인한다.
+/// 렌더러가 오염되어도 동의 없는 전송이 발생하지 않도록 IPC 진입점에서 게이트.
 #[tauri::command]
-pub async fn report_error(payload: ErrorReport) -> Result<(), String> {
+pub async fn report_error(
+    state: State<'_, RwLock<AppContainer>>,
+    payload: ErrorReport,
+) -> Result<(), String> {
+    let enabled = state
+        .read()
+        .map_err(|e| format!("settings read failed: {e}"))?
+        .get_settings()
+        .error_reporting_enabled;
+    if !enabled {
+        return Ok(());
+    }
     tauri::async_runtime::spawn_blocking(move || {
         let msg = format_report(&payload);
         send_to_telegram(&msg)
@@ -168,15 +185,40 @@ pub fn report_panic_sync(location: &str, message: &str) {
 ///   3. 성공 시 ".sent" suffix 로 rename (중복 전송 방지)
 ///
 /// 백그라운드 스레드에서 실행 (앱 시작 지연 방지).
-pub fn spawn_flush_pending_crash_logs() {
+///
+/// 사용자 설정 `error_reporting_enabled` 가 false 면 전송하지 않고 ".sent" 로 마킹만 한다
+/// (이전 세션에서 켜뒀다가 끈 경우 잔존 로그가 재전송되지 않도록).
+pub fn spawn_flush_pending_crash_logs(app_data_dir: PathBuf) {
     if TELEGRAM_BOT_TOKEN.is_empty() || TELEGRAM_CHAT_ID.is_empty() {
         return;
     }
-    std::thread::spawn(|| {
+    std::thread::spawn(move || {
         let Some(data_dir) = dirs::data_dir() else {
             return;
         };
         let crash_dir = data_dir.join("com.anything.app");
+        let Ok(entries) = std::fs::read_dir(&crash_dir) else {
+            return;
+        };
+
+        // 사용자 설정 백엔드 게이트 — false 면 모든 미전송 파일을 .sent 로 마킹만 하고 종료.
+        // (사용자가 토글을 끄기 전에 쌓인 잔존 로그가 다음 시작 때 재전송되는 것 차단)
+        let enabled =
+            crate::commands::settings::get_settings_sync(&app_data_dir).error_reporting_enabled;
+        if !enabled {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                    continue;
+                };
+                if name.starts_with("crash-") && !name.ends_with(".sent") {
+                    let new_path = path.with_file_name(format!("{}.sent", name));
+                    let _ = std::fs::rename(&path, &new_path);
+                }
+            }
+            return;
+        }
+        // 게이트 통과 — 정상 플러시 루프 진행
         let Ok(entries) = std::fs::read_dir(&crash_dir) else {
             return;
         };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -703,7 +703,8 @@ pub fn run() {
 
             // 이전 세션에서 남긴 미전송 crash log 를 Telegram 으로 지연 전송
             // (네이티브 크래시/OOM kill 등 panic hook 이 실행되지 못한 경우 대비)
-            commands::telemetry::spawn_flush_pending_crash_logs();
+            // 사용자 설정 백엔드 게이트는 함수 내부에서 처리한다.
+            commands::telemetry::spawn_flush_pending_crash_logs(container.app_data_dir.clone());
 
             // kordoc 사이드카 가용성 진단 — HWP5 는 Rust fallback 이 없어 kordoc 미가용 시 전수 실패한다.
             // 미가용이면 frontend 에 즉시 알려 인덱싱 시작 전에 사용자가 인지할 수 있게 한다 (이슈 #22).

--- a/src-tauri/src/utils/disk_info.rs
+++ b/src-tauri/src/utils/disk_info.rs
@@ -69,7 +69,14 @@ fn query_disk_type_wmi(drive_letter: char) -> Option<DiskType> {
     );
 
     let encoded = super::encode_powershell_command(&script);
-    let output = Command::new("powershell")
+    // PATH hijack 방지 — Windows PowerShell 5.x 풀패스 사용.
+    let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| String::from("C:\\Windows"));
+    let powershell = std::path::PathBuf::from(system_root)
+        .join("System32")
+        .join("WindowsPowerShell")
+        .join("v1.0")
+        .join("powershell.exe");
+    let output = Command::new(powershell)
         .args(["-NoProfile", "-NonInteractive", "-EncodedCommand", &encoded])
         .creation_flags(CREATE_NO_WINDOW)
         .output()

--- a/src/hooks/useAppSettings.ts
+++ b/src/hooks/useAppSettings.ts
@@ -64,7 +64,7 @@ export function useAppSettings({ setSearchMode, setMinConfidence }: UseAppSettin
         setSemanticEnabled(settings.semantic_search_enabled ?? false);
         setVectorIndexingMode(settings.vector_indexing_mode ?? "manual");
         setResultsPerPage(settings.results_per_page ?? 50);
-        setErrorReportingEnabled(settings.error_reporting_enabled ?? true);
+        setErrorReportingEnabled(settings.error_reporting_enabled ?? false);
 
         applyHighlightColors(settings);
       } catch {

--- a/src/utils/errorLogger.ts
+++ b/src/utils/errorLogger.ts
@@ -25,10 +25,11 @@ function reportRemote(
   message: string,
   context: Record<string, string>,
 ) {
-  // 설정 캐시 확인 — window 에 붙여두고 SettingsContext 에서 매번 갱신
+  // 설정 캐시 확인 — window 에 붙여두고 SettingsContext 에서 매번 갱신.
+  // 미초기화(undefined) 상태에서도 전송하지 않도록 명시적 true 만 통과시킨다.
   const enabled = (window as unknown as { __errorReportingEnabled?: boolean })
     .__errorReportingEnabled;
-  if (enabled === false) return;
+  if (enabled !== true) return;
   invoke("report_error", {
     payload: { source, title, message, context },
   }).catch(() => {});


### PR DESCRIPTION
## 배경

2026-05-17 prod review (Codex gpt-5.5 xhigh, 341k 토큰)에서 도출된 **출시 전 차단/중요 개선** 8건을 코드 대조로 재검증 → 즉시 적용 가능한 3건을 본 PR 에 묶음.

검증 보류: DB 평문 인덱스 (#3), 서명/공증 (#4·#5), lindera vendor (#7) — target user / 비용 / 작업 분량 결정이 필요한 사안으로 별도 트랙.

## 변경

### 1) Release pipeline 검증 게이트
- `ci.yml` 에 `workflow_call:` trigger 추가 → reusable workflow 화.
- `publish.yml` 의 `publish-tauri` / `publish-macos` 에 `needs: validate` 게이트.
- tag push 시 `tsc / cargo fmt / cargo check / cargo clippy -- -D warnings / cargo test` 가 빌드 전에 강제 실행됨.
- main 직접 푸시로 깨진 코드가 release 되는 경로 차단.

### 2) 원격 오류 리포팅 opt-in 전환
| 위치 | Before | After |
|---|---|---|
| `default_error_reporting_enabled` | `true` | `false` |
| `report_error` IPC | 백엔드 게이트 없음 | 사용자 설정 재확인 |
| `spawn_flush_pending_crash_logs` | 무조건 전송 | off 면 `.sent` 마킹만 |
| `useAppSettings` fallback | `?? true` | `?? false` |
| `errorLogger` 게이트 | `enabled === false` 만 차단 | `enabled !== true` 차단 |

- 렌더러 오염 시에도 동의 없는 전송 차단.
- 이전 세션에서 켜뒀다 끈 경우 잔존 crash log 도 재전송되지 않음.
- panic hook (`report_panic_sync`) 은 의도된 best-effort 유지 — default false 이므로 사용자가 명시적으로 켜야만 발동.

### 3) Windows 시스템 실행파일 PATH hijack 방지
- `explorer.exe` / `rundll32.exe` / `icacls.exe` / `powershell.exe` / `where.exe` 모두 PATH lookup 대신 `%SystemRoot%\System32\...` 풀패스로 호출.
- `SystemRoot` env 미정 시 `C:\Windows` fallback.
- helper 는 `commands/file.rs` 의 `windows_system32(exe)` (windows-only).

## 검증
- [x] `pnpm exec tsc --noEmit` — exit 0
- [x] `cargo fmt -- --check` — exit 0
- [x] `cargo check --all-targets` — exit 0
- [x] `cargo clippy --all-targets -- -D warnings` — exit 0
- [x] `cargo test` — 모든 테스트 pass
- [ ] CI 통과 확인 (이 PR 의 CI gate 본인 검증)
- [ ] 머지 후 release tag 생성 시 publish.yml 게이트 실행되는지 1회 모니터링

## 미적용 (별도 트랙)

| # | 항목 | 보류 사유 |
|---|---|---|
| 3 | DB 평문 인덱스 | target user 결정 필요 (SQLCipher 도입은 큰 작업) |
| 4 | Windows Authenticode 서명 | 인증서 ~$300/y |
| 5 | macOS Developer ID + notarization + entitlements 다이어트 | #4 와 묶음. 현재 ad-hoc 서명이라 entitlements 단독 fix 무의미 |
| 7 | lindera ko-dic vendor caching | CI rust-cache 가 평소 커버. 첫 빌드/캐시 미스/오프라인에서만 영향 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)