### PR TITLE
fix: 한글 파일명 검색 정규화

### DIFF
--- a/src-tauri/src/indexer/manager.rs
+++ b/src-tauri/src/indexer/manager.rs
@@ -669,7 +669,8 @@ impl WatchManager {
                     file_id: row.get(0)?,
                     path_lower: path_lower.into_boxed_str(),
                     path: path.into_boxed_str(),
-                    name_lower: name.to_lowercase().into_boxed_str(),
+                    name_lower: crate::search::filename_cache::normalize_filename_search_key(&name)
+                        .into_boxed_str(),
                     file_type: file_type.into_boxed_str(),
                     size: row.get(4)?,
                     modified_at: row.get(5)?,

--- a/src-tauri/src/search/filename.rs
+++ b/src-tauri/src/search/filename.rs
@@ -1,5 +1,18 @@
 use crate::db::escape_like_pattern;
 use rusqlite::Connection;
+use unicode_normalization::UnicodeNormalization;
+
+/// DB에는 기존 버전이 저장한 NFC/NFD 파일명이 섞여 있을 수 있다.
+/// 캐시가 잘려 SQLite 폴백을 쓰는 경우에도 두 정규형을 모두 조회한다.
+fn canonical_variants(value: &str) -> Vec<String> {
+    let nfc = crate::search::filename_cache::normalize_filename_search_key(value);
+    let nfd: String = nfc.nfd().collect();
+    if nfc == nfd {
+        vec![nfc]
+    } else {
+        vec![nfc, nfd]
+    }
+}
 
 /// 파일명 검색 (LIKE 기반 - 부분문자열 매칭 지원)
 /// FTS5 unicode61은 한글 부분문자열 매칭이 안 되므로 LIKE 사용
@@ -15,7 +28,7 @@ pub fn search(
     }
 
     // 여러 검색어를 AND로 연결
-    let terms: Vec<&str> = trimmed.split_whitespace().collect();
+    let terms: Vec<Vec<String>> = trimmed.split_whitespace().map(canonical_variants).collect();
 
     if terms.is_empty() {
         return Ok(vec![]);
@@ -25,15 +38,17 @@ pub fn search(
     // ESCAPE 절 추가로 특수문자 처리
     let mut where_clauses: Vec<String> = terms
         .iter()
-        .enumerate()
-        .map(|(i, _)| format!("name LIKE ?{} ESCAPE '\\'", i + 1))
+        .map(|variants| {
+            let clauses = vec!["name LIKE ? ESCAPE '\\'"; variants.len()];
+            format!("({})", clauses.join(" OR "))
+        })
         .collect();
 
     // folder_scope 필터 추가
     let scope_pattern = match folder_scope {
         Some(scope) if !scope.is_empty() => {
             let escaped = escape_like_pattern(scope);
-            where_clauses.push(format!("path LIKE ?{} ESCAPE '\\'", terms.len() + 1));
+            where_clauses.push("path LIKE ? ESCAPE '\\'".to_string());
             Some(format!("{}%", escaped))
         }
         _ => None,
@@ -59,6 +74,7 @@ pub fn search(
     // 파라미터 바인딩 (LIKE 패턴 이스케이프 + scope + limit)
     let like_patterns: Vec<String> = terms
         .iter()
+        .flatten()
         .map(|term| format!("%{}%", escape_like_pattern(term)))
         .collect();
 
@@ -110,4 +126,49 @@ pub struct FilenameResult {
     pub score: f64,
     /// 하이라이트된 파일명 (LIKE에서는 원본 파일명)
     pub highlight: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_db(name: &str) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE files (
+                id INTEGER PRIMARY KEY,
+                path TEXT NOT NULL,
+                name TEXT NOT NULL,
+                file_type TEXT NOT NULL,
+                size INTEGER,
+                modified_at INTEGER
+            )",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO files (path, name, file_type, size, modified_at)
+             VALUES (?1, ?2, 'jpg', 1, 0)",
+            rusqlite::params![format!("/tmp/{name}"), name],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn finds_nfd_filename_with_nfc_query() {
+        let decomposed = "\u{1100}\u{1169}\u{110b}\u{1163}\u{11bc}\u{110b}\u{1175}.jpg";
+        let conn = test_db(decomposed);
+
+        let results = search(&conn, "고양이", 10, None).unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn finds_nfc_filename_with_nfd_query() {
+        let conn = test_db("고양이.jpg");
+        let decomposed_query = "\u{1100}\u{1169}\u{110b}\u{1163}\u{11bc}\u{110b}\u{1175}";
+
+        let results = search(&conn, decomposed_query, 10, None).unwrap();
+        assert_eq!(results.len(), 1);
+    }
 }

--- a/src-tauri/src/search/filename_cache.rs
+++ b/src-tauri/src/search/filename_cache.rs
@@ -7,6 +7,14 @@ use rusqlite::Connection;
 use std::collections::HashMap;
 use std::sync::RwLock;
 
+/// 파일명 검색용 키를 생성한다.
+///
+/// macOS 파일명은 화면상 같은 한글도 NFD(분해형)로 저장될 수 있으므로,
+/// 캐시 값과 쿼리를 모두 NFC로 맞춘 뒤 소문자화해야 부분 문자열 검색이 일관된다.
+pub(crate) fn normalize_filename_search_key(value: &str) -> String {
+    crate::utils::normalize_text(value).to_lowercase()
+}
+
 /// 캐시 최대 엔트리 수 (~750MB 상한, 24GB RAM 환경 기준)
 ///
 /// 대용량 연구/아카이브 인덱싱 사용자 (100만 파일 이상) 지원을 위해 v2.6.9 에서
@@ -102,7 +110,7 @@ impl FilenameCache {
                 file_id: row.get(0)?,
                 path_lower: path_lower.into_boxed_str(),
                 path: path.into_boxed_str(),
-                name_lower: name.to_lowercase().into_boxed_str(),
+                name_lower: normalize_filename_search_key(&name).into_boxed_str(),
                 file_type: file_type.into_boxed_str(),
                 size: row.get(4)?,
                 modified_at: row.get(5)?,
@@ -167,7 +175,7 @@ impl FilenameCache {
         // 검색어들 (AND 조건)
         let terms: Vec<String> = trimmed
             .split_whitespace()
-            .map(|s| s.to_lowercase())
+            .map(normalize_filename_search_key)
             .collect();
 
         if terms.is_empty() {
@@ -287,7 +295,7 @@ mod tests {
             file_id: id,
             path_lower: path_lower.into_boxed_str(),
             path: path.into_boxed_str(),
-            name_lower: name.to_lowercase().into_boxed_str(),
+            name_lower: normalize_filename_search_key(name).into_boxed_str(),
             file_type: "txt".to_string().into_boxed_str(),
             size: 1000,
             modified_at: 0,
@@ -323,6 +331,26 @@ mod tests {
         assert_eq!(results.len(), 1);
 
         let results = cache.search("REPORT", 10);
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn test_search_normalizes_decomposed_hangul_filename() {
+        let cache = FilenameCache::new();
+        let decomposed = "\u{1100}\u{1169}\u{110b}\u{1163}\u{11bc}\u{110b}\u{1175}.jpg";
+        cache.upsert(create_test_entry(1, decomposed));
+
+        let results = cache.search("고양이", 10);
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn test_search_normalizes_decomposed_hangul_query() {
+        let cache = FilenameCache::new();
+        cache.upsert(create_test_entry(1, "고양이.jpg"));
+        let decomposed_query = "\u{1100}\u{1169}\u{110b}\u{1163}\u{11bc}\u{110b}\u{1175}";
+
+        let results = cache.search(decomposed_query, 10);
         assert_eq!(results.len(), 1);
     }
 


### PR DESCRIPTION
## 변경 내용

- 파일명 캐시의 키와 검색어를 소문자화하기 전에 NFC 형식으로 정규화합니다.
- SQLite 폴백 검색에서는 NFC와 NFD 형식을 모두 조회합니다.
- NFD 파일명을 NFC 검색어로 찾는 경우와 그 반대 경우에 대한 회귀 테스트를 추가합니다.

## 원인

macOS에서는 한글 파일명이 분해형인 NFD로 저장될 수 있지만, 입력기로 작성한 검색어는 일반적으로 NFC 형식입니다. 기존 파일명 캐시는 문자열을 소문자화만 했고 SQLite의 `LIKE` 검색도 유니코드 정규화를 수행하지 않아, 화면상 동일한 한글 문자열이 서로 일치하지 않을 수 있었습니다. 특히 이미지는 본문 텍스트가 없어 파일명 검색 의존도가 높기 때문에 문제가 두드러졌습니다.

## 수정 효과

이미지를 포함한 한글 파일명을 NFC/NFD 형식과 관계없이 일관되게 검색할 수 있습니다. 기존 데이터베이스를 마이그레이션할 필요는 없습니다. 캐시는 불러올 때 정규화되며, SQLite 폴백 검색은 두 정규형을 모두 처리합니다.

## 검증

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check` 통과
- `cargo test --manifest-path src-tauri/Cargo.toml` 통과 (278개 통과, 2개 제외, 실패 0개)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` 통과
