### PR TITLE
feat: AI 답변을 Markdown 파일로 저장

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -798,6 +798,7 @@ function AppContent() {
                       error={search.aiError}
                       onReset={search.resetAi}
                       currentQuestion={search.aiAskedQuery}
+                      searchScope={search.filters.searchScope}
                       onCite={handleCitationJump}
                       onExampleClick={(text) => {
                         search.setQuery(text);

--- a/src/components/search/AiAnswerPanel.tsx
+++ b/src/components/search/AiAnswerPanel.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { save } from "@tauri-apps/plugin-dialog";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -8,6 +9,8 @@ import "katex/dist/katex.min.css";
 import type { AiAnalysis, SourceRef } from "../../types/search";
 import { FileIcon } from "../ui/FileIcon";
 import { ResultContextMenu, useContextMenu } from "./ResultContextMenu";
+import { useUIContext } from "../../contexts/UIContext";
+import { buildAiAnswerMarkdown, toDefaultSavePath, toSafeFileStem } from "../../utils/aiAnswerMarkdown";
 
 interface Props {
   answer: string;
@@ -16,6 +19,8 @@ interface Props {
   error: string | null;
   onReset: () => void;
   currentQuestion?: string;
+  /** 질의에 사용된 검색 범위 폴더 — Markdown 저장 시 기본 폴더로 쓴다 */
+  searchScope?: string | null;
   onExampleClick?: (text: string) => void;
   /** AI 답변 [출처N] 또는 참조 문서 클릭 → 미리보기 인용 점프 */
   onCite?: (source: SourceRef) => void;
@@ -65,7 +70,8 @@ function linkifyCitations(text: string): string {
   return text.replace(/\[출처\s*:?\s*(\d+)\s*\]/g, (_m, n) => `[출처${n}](${CITE_SCHEME}${n})`);
 }
 
-function AiAnswerPanel({ answer, isStreaming, analysis, error, onReset, currentQuestion, onCite }: Props) {
+
+function AiAnswerPanel({ answer, isStreaming, analysis, error, onReset, currentQuestion, searchScope, onCite }: Props) {
   const handleOpenFile = useCallback((path: string) => {
     invoke("open_file", { path }).catch(() => {});
   }, []);
@@ -305,8 +311,13 @@ function AiAnswerPanel({ answer, isStreaming, analysis, error, onReset, currentQ
 
       {/* 하단 액션 바 */}
       {(analysis || error) && (
-        <CopyableActionBar answer={answer} analysis={analysis} onReset={onReset} />
-
+        <CopyableActionBar
+          answer={answer}
+          analysis={analysis}
+          onReset={onReset}
+          currentQuestion={currentQuestion}
+          searchScope={searchScope}
+        />
       )}
     </div>
   );
@@ -393,9 +404,55 @@ function SourceFileItem({
   );
 }
 
-/** 하단 액션 바 — 새 질문 + 복사 버튼 */
-function CopyableActionBar({ answer, analysis, onReset }: { answer: string; analysis: AiAnalysis | null; onReset: () => void }) {
+/** 하단 액션 바 — 새 질문 + 복사 + Markdown 저장 버튼 */
+function CopyableActionBar({
+  answer,
+  analysis,
+  onReset,
+  currentQuestion,
+  searchScope,
+}: {
+  answer: string;
+  analysis: AiAnalysis | null;
+  onReset: () => void;
+  currentQuestion?: string;
+  searchScope?: string | null;
+}) {
   const [copied, setCopied] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const { showToast, updateToast } = useUIContext();
+
+  // 답변 + 참조 문서를 .md 파일로 저장 (미리보기 패널과 같은 export_markdown 커맨드 사용)
+  const handleSaveMarkdown = useCallback(async () => {
+    const timestamp = new Date().toISOString().slice(0, 10);
+    let outputPath: string | null = null;
+    try {
+      outputPath = await save({
+        defaultPath: toDefaultSavePath(
+          searchScope,
+          `${toSafeFileStem(currentQuestion)}_${timestamp}.md`,
+        ),
+        filters: [{ name: "Markdown", extensions: ["md"] }],
+      });
+    } catch {
+      showToast("파일 저장 창 열기 실패", "error");
+      return;
+    }
+    if (!outputPath) return; // 사용자 취소
+
+    setIsSaving(true);
+    const toastId = showToast("Markdown 저장 중...", "loading");
+    try {
+      const content = buildAiAnswerMarkdown(currentQuestion, answer, analysis);
+      await invoke("export_markdown", { content, outputPath });
+      updateToast(toastId, { message: "Markdown 파일로 저장했습니다", type: "success" });
+    } catch (e) {
+      const msg = typeof e === "string" ? e : ((e as { message?: string })?.message ?? "저장 실패");
+      updateToast(toastId, { message: `저장 실패: ${msg}`, type: "error" });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [answer, analysis, currentQuestion, searchScope, showToast, updateToast]);
 
   const handleCopy = useCallback(async () => {
     try {
@@ -449,6 +506,23 @@ function CopyableActionBar({ answer, analysis, onReset }: { answer: string; anal
               </svg>
             )}
             {copied ? "복사됨" : "복사"}
+          </button>
+        )}
+        {answer && (
+          <button
+            onClick={handleSaveMarkdown}
+            disabled={isSaving}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] font-medium rounded-md transition-colors hover:bg-[var(--color-bg-tertiary)] disabled:opacity-50"
+            style={{ color: "var(--color-text-muted)" }}
+            aria-label="AI 답변을 Markdown 파일로 저장"
+            title="질문·답변·참조 문서를 .md 파일로 저장"
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+              <polyline points="17 21 17 13 7 13 7 21" />
+              <polyline points="7 3 7 8 15 8" />
+            </svg>
+            {isSaving ? "저장 중..." : "MD 저장"}
           </button>
         )}
       </div>

--- a/src/utils/aiAnswerMarkdown.ts
+++ b/src/utils/aiAnswerMarkdown.ts
@@ -1,0 +1,51 @@
+import { cleanPath } from "./cleanPath";
+import type { AiAnalysis } from "../types/search";
+
+/** 경로에서 파일명만 추출 */
+function basename(path: string): string {
+  return path.replace(/\\/g, "/").split("/").pop() || path;
+}
+
+/** AI 답변을 나중에 다시 찾아볼 수 있는 마크다운 문서로 조립.
+ *  본문의 [출처N] 표기는 그대로 두고, 아래 참조 문서 번호와 대응시킨다. */
+export function buildAiAnswerMarkdown(
+  question: string | undefined,
+  answer: string,
+  analysis: AiAnalysis | null,
+): string {
+  const lines: string[] = [`# ${question?.trim() || "AI 문서 분석 결과"}`, ""];
+
+  const meta = [new Date().toLocaleString("ko-KR")];
+  if (analysis?.model) meta.push(analysis.model);
+  lines.push(`> Anything AI 문서 분석 · ${meta.join(" · ")}`, "", answer.trim(), "");
+
+  const files = analysis?.source_files ?? [];
+  if (files.length > 0) {
+    lines.push("## 참조 문서", "");
+    files.forEach((path, i) => {
+      const hint = analysis?.sources?.[i]?.location_hint;
+      lines.push(`${i + 1}. **${basename(path)}**${hint ? ` — ${hint}` : ""}`);
+      lines.push(`   \`${cleanPath(path)}\``);
+    });
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/** 질문을 파일명으로 쓸 수 있게 정리 (경로 구분자·예약문자 제거) */
+export function toSafeFileStem(question: string | undefined): string {
+  const stem = (question ?? "").replace(/[<>:"/\\|?*\n\r\t]+/g, "_").trim();
+  return stem.slice(0, 40) || "AI_문서분석";
+}
+
+/** 검색 범위 폴더를 저장 다이얼로그 기본 위치로 삼는다.
+ *  범위 지정 없이(전체 검색) 질의했으면 파일명만 넘겨 OS 기본 위치를 쓴다. */
+export function toDefaultSavePath(
+  scope: string | null | undefined,
+  fileName: string,
+): string {
+  const dir = scope ? cleanPath(scope).replace(/[/\\]+$/, "") : "";
+  if (!dir) return fileName;
+  return `${dir}${dir.includes("\\") ? "\\" : "/"}${fileName}`;
+}


### PR DESCRIPTION
## 배경

AI 문서 분석은 여러 파일에 흩어진 내용을 한 답변으로 종합해 줍니다. 그런데 지금은 그 결과를 남길 방법이 클립보드 복사뿐이라, 답변을 닫으면 사라집니다.

같은 내용을 다시 보려면 질의를 반복해야 하는데, 로컬 LLM 환경에서는 한 번 답변에 수십 초가 걸리기도 합니다. 종합된 결과를 파일로 남겨 두면 재질의 없이 다시 찾아볼 수 있고, `.md`라 저장 부담도 없습니다.

미리보기 패널에는 이미 **Markdown 저장**이 있는데(문서 원문 대상), AI 답변에는 같은 경로가 없어 이 PR에서 연결합니다.

## 변경 사항

AI 답변 하단 액션 바(`새 질문` · `복사` 옆)에 **MD 저장** 버튼을 추가했습니다. 질문·답변·참조 문서를 한 문서로 묶어 저장합니다.

저장되는 형식:

```markdown
# 졸업 요건?

> Anything AI 문서 분석 · 2026. 8. 2. 오후 1:42:07 · qwen2.5:7b

최소 졸업학점은 37학점입니다 [출처1].

## 참조 문서

1. **학사운영규정.hwpx** — 페이지 3
   `C:\Users\me\aSSIST\학사운영규정.hwpx`
2. **졸업요건 안내.pdf**
   `/Users/me/aSSIST/졸업요건 안내.pdf`
```

- **저장 다이얼로그는 질의에 사용한 검색 범위 폴더에서 열립니다.** 찾은 문서가 있는 폴더에 정리본을 함께 두는 흐름이 자연스러워서입니다. 범위 없이(전체 검색) 물었을 때는 파일명만 넘겨 OS 기본 위치를 씁니다 — 참조 문서가 여러 폴더에 흩어져 있을 때 엉뚱한 폴더를 여는 것보다 낫다고 판단했습니다.
- 본문의 `[출처N]` 표기는 그대로 두고 아래 참조 문서 번호와 대응시켜, 나중에 근거 문서를 되짚을 수 있게 했습니다.
- 참조 문서 경로는 Windows extended-length 접두사(`\\?\`)를 정리해 기록합니다.
- 파일명 기본값은 질문에서 생성합니다(경로 구분자·예약문자 제거, 40자 제한). 질문이 없으면 `AI_문서분석`으로 대체합니다.

## 구현

**백엔드 변경이 없습니다.** 미리보기 패널이 쓰던 `commands::export::export_markdown`을 그대로 재사용했습니다.

따라서 경로 검증도 기존 로직을 그대로 따릅니다 — 확장자 강제, 부모 디렉터리 canonicalize, `BLOCKED_PATH_PATTERNS` 기반 시스템 폴더 차단, `create_new(true)`를 통한 덮어쓰기 방지(TOCTOU 방어), 50MB 상한. `tauri-plugin-fs` 같은 추가 권한도 필요하지 않습니다.

프론트엔드에서도 저장 다이얼로그(`@tauri-apps/plugin-dialog`)와 토스트(`useUIContext`) 모두 `PreviewPanel`의 `handleExportMarkdown`과 동일한 패턴을 따랐습니다. 취소·실패 처리도 같습니다.

마크다운 조립과 경로 유틸은 `src/utils/aiAnswerMarkdown.ts`로 분리했습니다. 처음에는 `AiAnswerPanel.tsx`에 두었는데, 컴포넌트 파일에서 비컴포넌트를 export 하면 React Fast Refresh가 깨져(`Could not Fast Refresh ... export is incompatible`) 개발 중 전체 리로드가 발생했습니다.

변경 파일은 3개입니다 — `AiAnswerPanel.tsx`, `App.tsx`(검색 범위 prop 전달), `utils/aiAnswerMarkdown.ts`(신규).

## 검증

- `pnpm run build` (tsc + vite), `tsc --noEmit` 통과
- **macOS(Apple Silicon)에서 `tauri dev`로 실구동 확인** — 버튼 노출, 저장 다이얼로그가 검색 범위 폴더에서 열리는 것, 저장된 `.md` 내용까지 확인했습니다
- 마크다운 조립·경로 조합 함수를 직접 실행해 경계 케이스 확인 — 참조 문서 유무, 질문 없음, Windows `\\?\` 경로, 경로 끝 구분자 중복
- Rust 변경이 없어 `cargo` 게이트에는 영향이 없습니다

Windows에서는 실행해 보지 못했습니다. 경로 조합은 구분자를 입력 경로에서 판별하도록 했고 `\\?\` 접두사도 벗겨내지만, 실기 확인이 필요하면 알려주세요.

## 참고

`buildAiAnswerMarkdown`은 순수 함수라 테스트하기 좋은 형태로 두었습니다. 프론트엔드 테스트 인프라가 아직 없어 테스트는 포함하지 않았는데, 도입하실 계획이 있으면 이 함수부터 추가하기 좋을 것 같습니다.

저장 형식이나 버튼 위치·문구는 프로젝트 방향에 맞게 조정해 주셔도 좋습니다.
