### PR TITLE
Update README with kordoc build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,17 @@ xattr -dr com.apple.quarantine /Applications/Anything.app
 ## 개발자용
 
 ```bash
+# `pnpm run bundle-kordoc` 에 필요
+git clone https://github.com/chrisryugj/kordoc # Docufinder 폴더 바깥에 클론
+cd kordoc
+npm install
+npm run build
+```
+
+```bash
 pnpm install          # 의존성 설치
 pnpm run download-model  # ONNX 모델 다운로드 (첫 빌드 시)
+pnpm run bundle-kordoc # kordoc 및 node.exe 번들링 (첫 빌드 시, kordoc 업데이트 시)
 pnpm tauri:dev        # 개발 모드
 pnpm tauri:build      # 프로덕션 빌드 (NSIS 설치파일 .exe)
 ```


### PR DESCRIPTION
기존에 작성된 `README.md` 의 개발자용 섹션의 빌드 단계를 따르면 프레시 클론, 프레시 빌드에서 `npm run tauri:dev` 명령 실행시 아래 오류가 발생합니다.

```
resource path `resources\node.exe` doesn't exist.
```

`pnpm run bundle-kordoc` 명령 실행시 `kordoc` 프로젝트와 `node.exe` 를 번들링하므로 해당 오류도 해결할 수 있으므로, 해당 내용을 `README.md` 에 추가했습니다.