### PR TITLE
Implement indexing by using installed MS Office

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -133,7 +133,11 @@ windows-sys = { version = "0.59", features = [
     # 이슈 #33: kordoc Node 사이드카 자식을 Job Object 에 묶어 앱 종료/크래시 시 자동 정리
     "Win32_System_JobObjects",
     # 이슈 #35: ONNX Runtime DLL 로드 실패 원인(GetLastError) 진단
-    "Win32_System_LibraryLoader"
+    "Win32_System_LibraryLoader",
+    # Index by using MS Office via Windows COM
+    "Win32_System_Variant",
+    "Win32_System_Ole",
+    "Win32_System_Com_StructuredStorage"
 ] }
 # Fixed-version WebView2 Runtime 지원 (이슈 #24): registry 미등록 환경에서도
 # EBWebView 폴더만 있으면 ICoreWebView2Environment 를 직접 만들어 wry 에 inject.

--- a/src-tauri/src/application/container.rs
+++ b/src-tauri/src/application/container.rs
@@ -163,6 +163,9 @@ impl AppContainer {
         crate::utils::cloud_detect::set_skip_enabled(cached_settings.skip_cloud_body_indexing);
         // 시스템 폴더 추가 허용 토글 초기화 — validate_watch_path 우회 분기에 사용
         crate::constants::set_allow_system_folders(cached_settings.allow_system_folders);
+        crate::constants::set_use_wincom_for_docx(cached_settings.use_wincom_for_docx);
+        crate::constants::set_use_wincom_for_xlsx(cached_settings.use_wincom_for_xlsx);
+        crate::constants::set_use_wincom_for_pptx(cached_settings.use_wincom_for_pptx);
 
         // data_root가 설정되어 있으면 해당 경로에 DB/벡터 저장
         // 보안: 사용자 입력 경로 검증 (심볼릭 링크, 드라이브 루트, 시스템 폴더 거부)

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -138,6 +138,15 @@ pub struct Settings {
     /// false면 상대시간("3일 전")을 표시하고 절대 날짜/시간은 툴팁으로 노출.
     #[serde(default = "default_show_absolute_time")]
     pub show_absolute_time: bool,
+
+    #[serde(default)]
+    pub use_wincom_for_docx: bool,
+
+    #[serde(default)]
+    pub use_wincom_for_xlsx: bool,
+
+    #[serde(default)]
+    pub use_wincom_for_pptx: bool,
 }
 
 fn default_show_result_path() -> bool {
@@ -286,6 +295,9 @@ impl Default for Settings {
             open_on_single_click: false,
             show_result_path: true,
             show_absolute_time: true,
+            use_wincom_for_docx: false,
+            use_wincom_for_xlsx: false,
+            use_wincom_for_pptx: false,
         }
     }
 }
@@ -790,6 +802,9 @@ pub async fn update_settings(
     crate::utils::cloud_detect::set_skip_enabled(settings.skip_cloud_body_indexing);
     // 시스템 폴더 추가 허용 토글 동기화 (validate_watch_path 즉시 반영)
     crate::constants::set_allow_system_folders(settings.allow_system_folders);
+    crate::constants::set_use_wincom_for_docx(settings.use_wincom_for_docx);
+    crate::constants::set_use_wincom_for_xlsx(settings.use_wincom_for_xlsx);
+    crate::constants::set_use_wincom_for_pptx(settings.use_wincom_for_pptx);
 
     tracing::info!("Settings saved to {:?}", settings_path);
 

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -20,6 +20,7 @@ pub fn set_use_wincom_for_docx(v: bool) {
     USE_WINCOM_FOR_DOCX.store(v, Ordering::Relaxed);
 }
 
+#[cfg(windows)]
 pub fn is_use_wincom_for_docx() -> bool {
     USE_WINCOM_FOR_DOCX.load(Ordering::Relaxed)
 }
@@ -30,6 +31,7 @@ pub fn set_use_wincom_for_xlsx(v: bool) {
     USE_WINCOM_FOR_XLSX.store(v, Ordering::Relaxed);
 }
 
+#[cfg(windows)]
 pub fn is_use_wincom_for_xlsx() -> bool {
     USE_WINCOM_FOR_XLSX.load(Ordering::Relaxed)
 }
@@ -40,6 +42,7 @@ pub fn set_use_wincom_for_pptx(v: bool) {
     USE_WINCOM_FOR_PPTX.store(v, Ordering::Relaxed);
 }
 
+#[cfg(windows)]
 pub fn is_use_wincom_for_pptx() -> bool {
     USE_WINCOM_FOR_PPTX.load(Ordering::Relaxed)
 }

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -14,6 +14,36 @@ pub fn is_allow_system_folders() -> bool {
     ALLOW_SYSTEM_FOLDERS.load(Ordering::Relaxed)
 }
 
+static USE_WINCOM_FOR_DOCX: AtomicBool = AtomicBool::new(false);
+
+pub fn set_use_wincom_for_docx(v: bool) {
+    USE_WINCOM_FOR_DOCX.store(v, Ordering::Relaxed);
+}
+
+pub fn is_use_wincom_for_docx() -> bool {
+    USE_WINCOM_FOR_DOCX.load(Ordering::Relaxed)
+}
+
+static USE_WINCOM_FOR_XLSX: AtomicBool = AtomicBool::new(false);
+
+pub fn set_use_wincom_for_xlsx(v: bool) {
+    USE_WINCOM_FOR_XLSX.store(v, Ordering::Relaxed);
+}
+
+pub fn is_use_wincom_for_xlsx() -> bool {
+    USE_WINCOM_FOR_XLSX.load(Ordering::Relaxed)
+}
+
+static USE_WINCOM_FOR_PPTX: AtomicBool = AtomicBool::new(false);
+
+pub fn set_use_wincom_for_pptx(v: bool) {
+    USE_WINCOM_FOR_PPTX.store(v, Ordering::Relaxed);
+}
+
+pub fn is_use_wincom_for_pptx() -> bool {
+    USE_WINCOM_FOR_PPTX.load(Ordering::Relaxed)
+}
+
 /// 지원하는 파일 확장자 목록
 /// 참고: "hwp"는 파서 미지원 (파싱 실패 시 변환 대상으로 수집됨, pipeline.rs 참조)
 pub const SUPPORTED_EXTENSIONS: &[&str] = &[

--- a/src-tauri/src/parsers/mod.rs
+++ b/src-tauri/src/parsers/mod.rs
@@ -9,9 +9,13 @@ pub mod pdf_sniff;
 pub mod pptx;
 pub mod rhwp;
 pub mod txt;
+#[cfg(windows)]
+pub mod wincom;
 pub mod xlsx;
 
 use crate::ocr::OcrEngine;
+#[cfg(windows)]
+use crate::parsers::wincom::{docx as wincom_docx, pptx as wincom_pptx, xlsx as wincom_xlsx};
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use thiserror::Error;
@@ -254,9 +258,27 @@ fn parse_file_inner(
             }
         })),
         "hwpx" => parse_with_timeout(path, 30, "HWPX", hwpx::parse),
-        "docx" => parse_with_timeout(path, 30, "DOCX", docx::parse),
-        "pptx" => parse_with_timeout(path, 30, "PPTX", pptx::parse),
-        "xlsx" | "xls" => parse_with_timeout(path, 15, "XLS/XLSX", xlsx::parse),
+        "docx" => {
+            let parse_result = parse_with_timeout(path, 30, "DOCX", docx::parse);
+            match parse_result {
+                Ok(doc) => Ok(doc),
+                Err(err) => wincom_fallback_docx(path, err),
+            }
+        }
+        "pptx" => {
+            let parse_result = parse_with_timeout(path, 30, "PPTX", pptx::parse);
+            match parse_result {
+                Ok(doc) => Ok(doc),
+                Err(err) => wincom_fallback_pptx(path, err),
+            }
+        }
+        "xlsx" | "xls" => {
+            let parse_result = parse_with_timeout(path, 15, "XLS/XLSX", xlsx::parse);
+            match parse_result {
+                Ok(doc) => Ok(doc),
+                Err(err) => wincom_fallback_xlsx(path, err),
+            }
+        }
         "pdf" => pdf::parse(path, ocr),
         ext if crate::constants::OCR_IMAGE_EXTENSIONS.contains(&ext) => {
             match ocr {
@@ -269,6 +291,50 @@ fn parse_file_inner(
         }
         _ => Err(ParseError::UnsupportedFileType(extension)),
     }
+}
+
+// --- wincom fallback wrappers (Windows-only; no-op on other platforms) --------
+
+#[cfg(windows)]
+fn wincom_fallback_docx(path: &Path, err: ParseError) -> Result<ParsedDocument, ParseError> {
+    if crate::constants::is_use_wincom_for_docx() {
+        parse_with_timeout(path, 30, "DOCX", wincom_docx::parse)
+    } else {
+        Err(err)
+    }
+}
+
+#[cfg(windows)]
+fn wincom_fallback_pptx(path: &Path, err: ParseError) -> Result<ParsedDocument, ParseError> {
+    if crate::constants::is_use_wincom_for_xlsx() {
+        parse_with_timeout(path, 30, "PPTX", wincom_pptx::parse)
+    } else {
+        Err(err)
+    }
+}
+
+#[cfg(windows)]
+fn wincom_fallback_xlsx(path: &Path, err: ParseError) -> Result<ParsedDocument, ParseError> {
+    if crate::constants::is_use_wincom_for_pptx() {
+        parse_with_timeout(path, 30, "XLS/XLSX", wincom_xlsx::parse)
+    } else {
+        Err(err)
+    }
+}
+
+#[cfg(not(windows))]
+fn wincom_fallback_docx(_path: &Path, err: ParseError) -> Result<ParsedDocument, ParseError> {
+    Err(err)
+}
+
+#[cfg(not(windows))]
+fn wincom_fallback_pptx(_path: &Path, err: ParseError) -> Result<ParsedDocument, ParseError> {
+    Err(err)
+}
+
+#[cfg(not(windows))]
+fn wincom_fallback_xlsx(_path: &Path, err: ParseError) -> Result<ParsedDocument, ParseError> {
+    Err(err)
 }
 
 /// 공통 타임아웃 + 패닉 방어 래퍼 (HWPX, DOCX, PPTX, XLSX 공통)

--- a/src-tauri/src/parsers/wincom/docx.rs
+++ b/src-tauri/src/parsers/wincom/docx.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use super::{to_parse_error, v_string, var_bool, var_i32, var_str, AppGuard, ComApartment, Obj};
+use super::{to_parse_error, v_string, var_bool, var_i32, var_str, AppGuard, AppKind, ComApartment, Obj};
 use crate::parsers::{
     DocumentChunk, DocumentMetadata, ParseError, ParsedDocument, DEFAULT_CHUNK_OVERLAP,
     DEFAULT_CHUNK_SIZE, MAX_FILE_SIZE,
@@ -71,7 +71,7 @@ pub fn parse(path: &Path) -> Result<ParsedDocument, ParseError> {
 /// Open 시 가짜 암호를 전달해 보호된 문서의 모달 다이얼로그를 차단한다.
 fn extract_text(path: &Path) -> windows::core::Result<String> {
     let app = Obj::create("Word.Application")?;
-    let _guard = AppGuard::new(&app);
+    let _guard = AppGuard::new(&app, AppKind::Word);
     // Word 를 백그라운드로 실행 — 경고·화면 갱신·매크로 모두 차단.
     let _ = app.put("Visible", var_bool(false));
     let _ = app.put("DisplayAlerts", var_i32(WD_ALERTS_NONE));

--- a/src-tauri/src/parsers/wincom/docx.rs
+++ b/src-tauri/src/parsers/wincom/docx.rs
@@ -1,0 +1,186 @@
+//! Windows COM(Word.Application) 기반 DOCX 파서 — Windows 전용.
+//!
+//! `parsers::docx` (Rust ZIP/XML 파서) 실패 시 `wincom_fallback_docx` 에서 호출.
+//! 설치된 Word 로 문서를 열어 `Content.Text` 를 추출한다.
+
+use std::path::Path;
+
+use super::{to_parse_error, v_string, var_bool, var_i32, var_str, AppGuard, ComApartment, Obj};
+use crate::parsers::{
+    DocumentChunk, DocumentMetadata, ParseError, ParsedDocument, DEFAULT_CHUNK_OVERLAP,
+    DEFAULT_CHUNK_SIZE, MAX_FILE_SIZE,
+};
+
+/// `WdSaveOptions::wdDoNotSaveChanges` — Close 시 저장하지 않음.
+const WD_DO_NOT_SAVE_CHANGES: i32 = 0;
+/// `WdAlertLevel::wdAlertsNone` — 경고 대화상자 비활성.
+const WD_ALERTS_NONE: i32 = 0;
+
+/// DOCX 파일을 COM(Word.Application) 으로 파싱.
+///
+/// `parse_with_timeout` 래퍼를 통해 별도 STA 스레드에서 실행되며,
+/// 타임아웃·패닉 방어가 적용된다.
+pub fn parse(path: &Path) -> Result<ParsedDocument, ParseError> {
+    // 파일 크기 체크 (대용량 파일 메모리 보호)
+    if let Ok(metadata) = std::fs::metadata(path) {
+        if metadata.len() > MAX_FILE_SIZE {
+            return Err(ParseError::ParseError(format!(
+                "DOCX 파일 크기 초과: {}MB (최대 {}MB)",
+                metadata.len() / 1024 / 1024,
+                MAX_FILE_SIZE / 1024 / 1024
+            )));
+        }
+    }
+
+    let _com = ComApartment::init();
+
+    let full_text = extract_text(path).map_err(|e| to_parse_error("Word", &e))?;
+    let pages = split_pages(&full_text);
+    if pages.is_empty() {
+        tracing::warn!("DOCX(COM) file has no text content: {:?}", path);
+    }
+    let total_text = pages
+        .iter()
+        .map(|p| p.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let chunks = chunk_pages(&pages, DEFAULT_CHUNK_SIZE, DEFAULT_CHUNK_OVERLAP);
+    let page_count = pages.len();
+
+    Ok(ParsedDocument {
+        content: total_text,
+        metadata: DocumentMetadata {
+            title: path.file_stem().and_then(|s| s.to_str()).map(String::from),
+            author: None,
+            created_at: None,
+            page_count: if page_count > 1 {
+                Some(page_count)
+            } else {
+                None
+            },
+        },
+        chunks,
+        garbled_hint: false,
+    })
+}
+
+/// Word 를 COM 자동화로 구동해 문서 전체 텍스트 추출.
+///
+/// Application 객체 생성 → 보안 설정(Visible/DisplayAlerts/ScreenUpdating/AutomationSecurity)
+/// → `Documents.Open` → `Content.Text` 읽기 → `Close` 순서로 동작.
+/// Open 시 가짜 암호를 전달해 보호된 문서의 모달 다이얼로그를 차단한다.
+fn extract_text(path: &Path) -> windows::core::Result<String> {
+    let app = Obj::create("Word.Application")?;
+    let _guard = AppGuard::new(&app);
+    // Word 를 백그라운드로 실행 — 경고·화면 갱신·매크로 모두 차단.
+    let _ = app.put("Visible", var_bool(false));
+    let _ = app.put("DisplayAlerts", var_i32(WD_ALERTS_NONE));
+    let _ = app.put("ScreenUpdating", var_bool(false));
+    let _ = app.put(
+        "AutomationSecurity",
+        var_i32(super::MSO_AUTOMATION_SECURITY_FORCE_DISABLE),
+    );
+
+    let documents = app.get_obj("Documents", &[])?;
+    let path_str = super::path_arg(path);
+    let doc_var = documents.call(
+        "Open",
+        &[
+            var_str(&path_str),             // FileName — 절대 경로
+            var_bool(false),                // ConfirmConversions — 변환 확인 대화상자 비활성
+            var_bool(true),                 // ReadOnly — 읽기 전용
+            var_bool(false),                // AddToRecentFiles — 최근 문서 목록 추가 안 함
+            var_str(super::BOGUS_PASSWORD), // PasswordDocument — 가짜 암호 (보호 문서 즉시 실패)
+        ],
+    )?;
+    let doc = super::as_obj(&doc_var)?;
+
+    // Content 객체의 Text 속성에서 전체 문서 텍스트를 한 번에 읽는다.
+    let content = doc.get_obj("Content", &[])?;
+    let text_var = content.get("Text", &[])?;
+    let text = v_string(&text_var);
+
+    let _ = doc.call("Close", &[var_i32(WD_DO_NOT_SAVE_CHANGES)]);
+
+    Ok(text)
+}
+
+/// 페이지별 텍스트 정보 (페이지 번호 + 텍스트 + 전문 기준 시작 오프셋).
+struct PageText {
+    page_number: usize,
+    text: String,
+    start_offset: usize,
+}
+
+/// 폼 피드(`\u{000C}`) 기준 페이지 분할.
+/// Word `Content.Text` 는 페이지 경계를 폼 피드 문자로 구분한다.
+fn split_pages(full: &str) -> Vec<PageText> {
+    let mut pages: Vec<PageText> = Vec::new();
+    let mut running_offset = 0usize;
+
+    for (idx, raw_page) in full.split('\u{000C}').enumerate() {
+        let text = normalize_paragraphs(raw_page);
+        if text.is_empty() {
+            continue;
+        }
+        let char_len = text.chars().count();
+        pages.push(PageText {
+            page_number: idx + 1,
+            text,
+            start_offset: running_offset,
+        });
+        running_offset += char_len + 1;
+    }
+
+    pages
+}
+
+/// 단락 구분자 정규화 — CR/LF/수직탭/벨/Shift-In 등을 `\n`으로 통일하고
+/// 빈 줄을 제거한다.
+fn normalize_paragraphs(page: &str) -> String {
+    page.split(['\r', '\n', '\u{000B}', '\u{0007}', '\u{000E}'])
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// 페이지별 청크 분할 (페이지 번호·위치 힌트 유지).
+/// 각 페이지 내부에서 `chunk_size` 크기로 분할하고 `overlap` 만큼 겹친다.
+fn chunk_pages(pages: &[PageText], chunk_size: usize, overlap: usize) -> Vec<DocumentChunk> {
+    let mut chunks = Vec::new();
+
+    for page in pages {
+        let chars: Vec<char> = page.text.chars().collect();
+        let total_len = chars.len();
+
+        if total_len == 0 {
+            continue;
+        }
+
+        let step = chunk_size.saturating_sub(overlap).max(1);
+        let mut start = 0;
+
+        while start < total_len {
+            let end = (start + chunk_size).min(total_len);
+            let chunk_content: String = chars[start..end].iter().collect();
+
+            chunks.push(DocumentChunk {
+                content: chunk_content,
+                start_offset: page.start_offset + start,
+                end_offset: page.start_offset + end,
+                page_number: Some(page.page_number),
+                page_end: Some(page.page_number),
+                location_hint: Some(format!("페이지 {}", page.page_number)),
+            });
+
+            start += step;
+
+            if end >= total_len {
+                break;
+            }
+        }
+    }
+
+    chunks
+}

--- a/src-tauri/src/parsers/wincom/docx.rs
+++ b/src-tauri/src/parsers/wincom/docx.rs
@@ -5,7 +5,9 @@
 
 use std::path::Path;
 
-use super::{to_parse_error, v_string, var_bool, var_i32, var_str, AppGuard, AppKind, ComApartment, Obj};
+use super::{
+    to_parse_error, v_string, var_bool, var_i32, var_str, AppGuard, AppKind, ComApartment, Obj,
+};
 use crate::parsers::{
     DocumentChunk, DocumentMetadata, ParseError, ParsedDocument, DEFAULT_CHUNK_OVERLAP,
     DEFAULT_CHUNK_SIZE, MAX_FILE_SIZE,

--- a/src-tauri/src/parsers/wincom/mod.rs
+++ b/src-tauri/src/parsers/wincom/mod.rs
@@ -307,7 +307,10 @@ pub(crate) struct AppGuard {
 
 impl AppGuard {
     pub(crate) fn new(app: &Obj, kind: AppKind) -> Self {
-        AppGuard { app: app.clone(), kind }
+        AppGuard {
+            app: app.clone(),
+            kind,
+        }
     }
 
     fn collection_size(&self) -> windows::core::Result<i32> {

--- a/src-tauri/src/parsers/wincom/mod.rs
+++ b/src-tauri/src/parsers/wincom/mod.rs
@@ -1,0 +1,332 @@
+//! Windows COM 자동화 기반 Office 문서 파서 (Windows 전용)
+//!
+//! 설치된 MS Office (Word · PowerPoint · Excel) 를 COM IDispatch 지연 바인딩으로
+//! 구동해 문서 본문을 추출한다. Rust ZIP/XML 파서(`parsers::docx` 등) 가 처리하지
+//! 못하는 레거시 포맷(.doc, .ppt, .xls) 이나 손상된 OOXML 의 fallback 경로로
+//! `parsers/mod.rs` 의 `wincom_fallback_*` 래퍼에서 호출된다.
+//!
+//! 핵심 설계:
+//! - 모든 COM 호출은 별도 STA(단일 스레드 아파트먼트) 스레드에서 실행 —
+//!   Office COM 은 STA 를 요구하며 `parse_with_timeout` 래퍼와 짝을 이룸.
+//! - 암호 문서 대비: Open 시 항상 가짜 암호(`BOGUS_PASSWORD`) 전달 →
+//!   보호된 문서는 즉시 password 에러로 실패 (시스템 모달 다이얼로그 차단),
+//!   비보호 문서는 무시됨.
+//! - 매크로 보안: `AutomationSecurity = ForceDisable` 로 Open 시 매크로 자동실행 차단.
+
+pub mod docx;
+pub mod pptx;
+pub mod xlsx;
+
+use std::path::Path;
+
+use windows::core::{BSTR, GUID, PCWSTR};
+use windows::Win32::System::Com::{
+    CLSIDFromProgID, CoCreateInstance, CoInitializeEx, CoUninitialize, IDispatch,
+    CLSCTX_LOCAL_SERVER, COINIT_APARTMENTTHREADED, DISPATCH_FLAGS, DISPATCH_METHOD,
+    DISPATCH_PROPERTYGET, DISPATCH_PROPERTYPUT, DISPPARAMS,
+};
+use windows::Win32::System::Ole::DISPID_PROPERTYPUT;
+use windows::Win32::System::Variant::{
+    VariantChangeType, VARIANT, VARIANT_0, VARIANT_0_0, VARIANT_0_0_0, VAR_CHANGE_FLAGS, VT_ARRAY,
+    VT_BSTR, VT_EMPTY, VT_ERROR, VT_NULL,
+};
+
+use crate::parsers::ParseError;
+
+// ============================================================================
+// Office 자동화 상수
+// ============================================================================
+
+/// `IDispatch::Invoke` 호출 시 사용하는 lcid — 시스템 기본 로케일.
+const LOCALE_USER_DEFAULT: u32 = 0x0400;
+
+/// MsoTriState — Office 자동화의 불리언 값 (msoTrue = -1, msoFalse = 0).
+const MSO_TRUE: i32 = -1;
+const MSO_FALSE: i32 = 0;
+
+/// `MsoAutomationSecurity::msoAutomationSecurityForceDisable` —
+/// 파일 열 때 매크로 자동 실행을 완전히 차단 (매크로 바이러스 방어).
+const MSO_AUTOMATION_SECURITY_FORCE_DISABLE: i32 = 3;
+
+/// Word 가 암호 불일치 시 반환하는 HRESULT 값.
+const WORD_ERR_WRONG_PASSWORD: i32 = 0x800A_1533u32 as i32;
+
+/// 보호된 문서에 전달하는 가짜 암호 — Open 호출이 모달 다이얼로그를 띄우지 않고
+/// 즉시 password 에러로 실패하도록 유도 (`to_parse_error` 가 `PasswordProtected` 로 변환).
+/// 비보호 문서에서는 Word 가 이 값을 무시한다.
+const BOGUS_PASSWORD: &str = "\u{1}docufinder-com-noopen\u{1}";
+
+// ============================================================================
+// COM 아파트먼트 가드
+// ============================================================================
+
+/// COM 호출을 위한 단일 스레드 아파트먼트(STA) RAII 가드.
+///
+/// Office COM 자동화는 STA 를 요구한다. `CoInitializeEx` 로 아파트먼트를 초기화하고
+/// drop 시 `CoUninitialize` 로 정리한다. 이미 초기화된 스레드에서 재호출 시
+/// `S_FALSE` 를 반환하므로, `should_uninit` 플래그로 중복 해제를 방지한다.
+pub(crate) struct ComApartment {
+    should_uninit: bool,
+}
+
+impl ComApartment {
+    /// 현재 스레드를 STA 로 초기화. 이미 초기화된 경우 uninitialize 하지 않는다.
+    pub(crate) fn init() -> Self {
+        let hr = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+        ComApartment {
+            should_uninit: hr.is_ok(),
+        }
+    }
+}
+
+impl Drop for ComApartment {
+    fn drop(&mut self) {
+        if self.should_uninit {
+            unsafe {
+                CoUninitialize();
+            }
+        }
+    }
+}
+
+// ============================================================================
+// IDispatch 래퍼
+// ============================================================================
+
+/// COM 자동화 객체(`IDispatch`) 래퍼 — VBA 스타일 지연 바인딩(late-binding) 호출.
+#[derive(Clone)]
+pub(crate) struct Obj(IDispatch);
+
+impl Obj {
+    /// `prog_id` (예: "Word.Application") 로 최상위 Application 객체 생성.
+    pub(crate) fn create(prog_id: &str) -> windows::core::Result<Obj> {
+        let wide = to_wide(prog_id);
+        let clsid: GUID = unsafe { CLSIDFromProgID(PCWSTR(wide.as_ptr())) }?;
+        let disp: IDispatch = unsafe { CoCreateInstance(&clsid, None, CLSCTX_LOCAL_SERVER) }?;
+        Ok(Obj(disp))
+    }
+
+    /// 메서드/속성 이름 → DISPID 조회 (`IDispatch::GetIDsOfNames`).
+    fn dispid(&self, name: &str) -> windows::core::Result<i32> {
+        let wide = to_wide(name);
+        let names = [PCWSTR(wide.as_ptr())];
+        let mut id = 0i32;
+        unsafe {
+            self.0.GetIDsOfNames(
+                &GUID::zeroed(),
+                names.as_ptr(),
+                1,
+                LOCALE_USER_DEFAULT,
+                &mut id,
+            )
+        }?;
+        Ok(id)
+    }
+
+    /// `IDispatch::Invoke` 저수준 래퍼.
+    /// 인자를 역순으로 배치(VARIANT 역순 규약)하며, property put 시
+    /// `DISPID_PROPERTYPUT` named arg 를 설정한다.
+    fn invoke(
+        &self,
+        name: &str,
+        flags: DISPATCH_FLAGS,
+        args: &[VARIANT],
+    ) -> windows::core::Result<VARIANT> {
+        let dispid = self.dispid(name)?;
+
+        let mut rev: Vec<VARIANT> = args.iter().rev().cloned().collect();
+        let mut named_put = DISPID_PROPERTYPUT;
+
+        let mut params = DISPPARAMS::default();
+        if !rev.is_empty() {
+            params.rgvarg = rev.as_mut_ptr();
+            params.cArgs = rev.len() as u32;
+        }
+        if flags == DISPATCH_PROPERTYPUT {
+            params.cNamedArgs = 1;
+            params.rgdispidNamedArgs = &mut named_put;
+        }
+
+        let mut result = VARIANT::default();
+        unsafe {
+            self.0.Invoke(
+                dispid,
+                &GUID::zeroed(),
+                LOCALE_USER_DEFAULT,
+                flags,
+                &params,
+                Some(&mut result),
+                None,
+                None,
+            )
+        }?;
+        Ok(result)
+    }
+
+    /// 메서드 호출 (예: Open, Close, Quit).
+    pub(crate) fn call(&self, name: &str, args: &[VARIANT]) -> windows::core::Result<VARIANT> {
+        self.invoke(name, DISPATCH_METHOD, args)
+    }
+
+    /// 속성 읽기 (예: Count, Text, Item(i)).
+    pub(crate) fn get(&self, name: &str, args: &[VARIANT]) -> windows::core::Result<VARIANT> {
+        self.invoke(name, DISPATCH_PROPERTYGET | DISPATCH_METHOD, args)
+    }
+
+    /// 속성 쓰기 (예: Visible, DisplayAlerts).
+    pub(crate) fn put(&self, name: &str, value: VARIANT) -> windows::core::Result<()> {
+        self.invoke(name, DISPATCH_PROPERTYPUT, &[value])?;
+        Ok(())
+    }
+
+    /// 자식 객체 획득 (예: Documents, Content, Slides, UsedRange).
+    pub(crate) fn get_obj(&self, name: &str, args: &[VARIANT]) -> windows::core::Result<Obj> {
+        as_obj(&self.get(name, args)?)
+    }
+
+    /// 정수 속성 읽기 — 실패 시 0.
+    pub(crate) fn get_i32(&self, name: &str, args: &[VARIANT]) -> i32 {
+        self.get(name, args).map(|v| v_i32(&v)).unwrap_or(0)
+    }
+
+    /// 문자열 속성 읽기 — 실패 시 빈 문자열.
+    pub(crate) fn get_string(&self, name: &str, args: &[VARIANT]) -> String {
+        self.get(name, args)
+            .map(|v| v_string(&v))
+            .unwrap_or_default()
+    }
+}
+
+// ============================================================================
+// VARIANT 변환 유틸리티
+// ============================================================================
+
+/// 결과 VARIANT(`VT_DISPATCH`) 에서 자식 Obj 추출.
+pub(crate) fn as_obj(v: &VARIANT) -> windows::core::Result<Obj> {
+    Ok(Obj(IDispatch::try_from(v)?))
+}
+
+/// VARIANT → i32 (숫자/불리언/문자 강제 변환), 실패 시 0.
+pub(crate) fn v_i32(v: &VARIANT) -> i32 {
+    i32::try_from(v).unwrap_or(0)
+}
+
+/// VARIANT → String (`VT_BSTR` 및 강제 변환 가능 타입).
+pub(crate) fn v_string(v: &VARIANT) -> String {
+    BSTR::try_from(v).map(|b| b.to_string()).unwrap_or_default()
+}
+
+/// 임의 스칼라 VARIANT → 로케일 문자열 (날짜·통화 등 `VariantChangeType` 사용).
+pub(crate) fn v_to_display_string(v: &VARIANT) -> String {
+    let mut dest = VARIANT::default();
+    let ok = unsafe { VariantChangeType(&mut dest, v, VAR_CHANGE_FLAGS(0), VT_BSTR).is_ok() };
+    if ok {
+        v_string(&dest)
+    } else {
+        String::new()
+    }
+}
+
+/// `VT_ARRAY`(`SAFEARRAY`) 여부 확인.
+pub(crate) fn v_is_array(v: &VARIANT) -> bool {
+    (v.vt().0 & VT_ARRAY.0) != 0
+}
+
+/// `VT_EMPTY` 또는 `VT_NULL` 여부 확인.
+pub(crate) fn v_is_empty(v: &VARIANT) -> bool {
+    let vt = v.vt();
+    vt == VT_EMPTY || vt == VT_NULL
+}
+
+/// 생략된 선택 인자 — positional 인자 사이의 빈 칸을 채운다.
+/// COM 자동화에서 `Workbooks.Open` 의 Format 인자처럼 생략하는 파라미터는
+/// `VT_ERROR` + `DISP_E_PARAMNOTFOUND` 로 표현한다.
+const DISP_E_PARAMNOTFOUND: i32 = 0x8002_0004u32 as i32;
+pub(crate) fn missing_arg() -> VARIANT {
+    VARIANT {
+        Anonymous: VARIANT_0 {
+            Anonymous: core::mem::ManuallyDrop::new(VARIANT_0_0 {
+                vt: VT_ERROR,
+                wReserved1: 0,
+                wReserved2: 0,
+                wReserved3: 0,
+                Anonymous: VARIANT_0_0_0 {
+                    scode: DISP_E_PARAMNOTFOUND,
+                },
+            }),
+        },
+    }
+}
+
+// ============================================================================
+// VARIANT 생성 헬퍼
+// ============================================================================
+
+pub(crate) fn var_str(s: &str) -> VARIANT {
+    VARIANT::from(s)
+}
+pub(crate) fn var_i32(n: i32) -> VARIANT {
+    VARIANT::from(n)
+}
+pub(crate) fn var_bool(b: bool) -> VARIANT {
+    VARIANT::from(b)
+}
+
+/// UTF-16 널 종단 wide 문자열 변환 (COM API 호출용).
+fn to_wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+// ============================================================================
+// Application 객체 수명 가드
+// ============================================================================
+
+/// Application 객체의 RAII 가드 — drop 시 `Quit` 호출로 Office 프로세스 종료.
+/// 잔존 `WINWORD.EXE` / `POWERPNT.EXE` / `EXCEL.EXE` 가 메모리·핸들을 점유하므로
+/// 반드시 정리해야 한다.
+pub(crate) struct AppGuard {
+    app: Obj,
+}
+
+impl AppGuard {
+    pub(crate) fn new(app: &Obj) -> Self {
+        AppGuard { app: app.clone() }
+    }
+}
+
+impl Drop for AppGuard {
+    fn drop(&mut self) {
+        let _ = self.app.call("Quit", &[]);
+    }
+}
+
+// ============================================================================
+// 에러 변환 · 경로 헬퍼
+// ============================================================================
+
+/// `windows::core::Error` → `ParseError` 변환.
+/// HRESULT 또는 메시지에서 암호 관련 키워드(password, 암호, encrypt) 가 발견되면
+/// `PasswordProtected` 로, 그 외는 일반 COM 오류로 매핑한다.
+pub(crate) fn to_parse_error(context: &str, e: &windows::core::Error) -> ParseError {
+    let code = e.code().0;
+    let msg = e.message();
+    let lower = msg.to_lowercase();
+    if code == WORD_ERR_WRONG_PASSWORD
+        || lower.contains("password")
+        || lower.contains("암호")
+        || lower.contains("encrypt")
+    {
+        ParseError::PasswordProtected(format!("암호로 보호된 문서입니다 ({context})"))
+    } else {
+        ParseError::ParseError(format!("{context} COM 오류: {msg} (0x{:08X})", code as u32))
+    }
+}
+
+/// 파일 경로를 COM `Open` 호출에 넘길 절대 경로 문자열로 정규화.
+/// `dunce` 로 UNC `\\?\` prefix 를 단순화 — Office 가 prefix 를 못 읽는 경우 방지.
+pub(crate) fn path_arg(path: &Path) -> String {
+    std::fs::canonicalize(path)
+        .ok()
+        .and_then(|p| dunce::simplified(&p).to_str().map(String::from))
+        .unwrap_or_else(|| path.to_string_lossy().to_string())
+}

--- a/src-tauri/src/parsers/wincom/mod.rs
+++ b/src-tauri/src/parsers/wincom/mod.rs
@@ -281,22 +281,55 @@ fn to_wide(s: &str) -> Vec<u16> {
 // Application 객체 수명 가드
 // ============================================================================
 
+pub(crate) enum AppKind {
+    Word,
+    Excel,
+    PowerPoint,
+}
+
+impl AppKind {
+    fn collection_name(&self) -> &'static str {
+        match self {
+            Self::Word => "Documents",
+            Self::Excel => "Workbooks",
+            Self::PowerPoint => "Presentations",
+        }
+    }
+}
+
 /// Application 객체의 RAII 가드 — drop 시 `Quit` 호출로 Office 프로세스 종료.
 /// 잔존 `WINWORD.EXE` / `POWERPNT.EXE` / `EXCEL.EXE` 가 메모리·핸들을 점유하므로
 /// 반드시 정리해야 한다.
 pub(crate) struct AppGuard {
     app: Obj,
+    kind: AppKind,
 }
 
 impl AppGuard {
-    pub(crate) fn new(app: &Obj) -> Self {
-        AppGuard { app: app.clone() }
+    pub(crate) fn new(app: &Obj, kind: AppKind) -> Self {
+        AppGuard { app: app.clone(), kind }
+    }
+
+    fn collection_size(&self) -> windows::core::Result<i32> {
+        let collection = self.app.get_obj(self.kind.collection_name(), &[])?;
+        let count = collection.get("Count", &[])?;
+        i32::try_from(&count)
     }
 }
 
 impl Drop for AppGuard {
     fn drop(&mut self) {
-        let _ = self.app.call("Quit", &[]);
+        let should_quit = match self.kind {
+            AppKind::Word | AppKind::Excel => true,
+            AppKind::PowerPoint => match self.collection_size() {
+                Ok(0) => true,
+                Ok(_count) => false,
+                Err(_err) => false, // TODO: tracing::warn!
+            },
+        };
+        if should_quit {
+            let _ = self.app.call("Quit", &[]);
+        }
     }
 }
 

--- a/src-tauri/src/parsers/wincom/pptx.rs
+++ b/src-tauri/src/parsers/wincom/pptx.rs
@@ -1,0 +1,242 @@
+//! Windows COM(PowerPoint.Application) 기반 PPTX 파서 — Windows 전용.
+//!
+//! `parsers::pptx` (Rust ZIP/XML 파서) 실패 시 `wincom_fallback_pptx` 에서 호출.
+//! 설치된 PowerPoint 로 프레젠테이션을 열어 각 슬라이드의 도형(Shape) 텍스트와
+//! 노트(NotesPage) 텍스트를 추출한다.
+
+use std::path::Path;
+
+use super::{
+    to_parse_error, v_string, var_i32, var_str, AppGuard, ComApartment, Obj, MSO_FALSE, MSO_TRUE,
+};
+use crate::parsers::{
+    DocumentChunk, DocumentMetadata, ParseError, ParsedDocument, DEFAULT_CHUNK_OVERLAP,
+    DEFAULT_CHUNK_SIZE, MAX_FILE_SIZE,
+};
+
+/// `PpAlertLevel::ppAlertsNone` — 경고 대화상자 비활성.
+const PP_ALERTS_NONE: i32 = 1;
+
+/// PPTX 파일을 COM(PowerPoint.Application) 으로 파싱.
+///
+/// `parse_with_timeout` 래퍼를 통해 별도 STA 스레드에서 실행되며,
+/// 타임아웃·패닉 방어가 적용된다.
+pub fn parse(path: &Path) -> Result<ParsedDocument, ParseError> {
+    // 파일 크기 체크 (대용량 파일 메모리 보호)
+    if let Ok(metadata) = std::fs::metadata(path) {
+        if metadata.len() > MAX_FILE_SIZE {
+            return Err(ParseError::ParseError(format!(
+                "PPTX 파일 크기 초과: {}MB (최대 {}MB)",
+                metadata.len() / 1024 / 1024,
+                MAX_FILE_SIZE / 1024 / 1024
+            )));
+        }
+    }
+
+    let _com = ComApartment::init();
+
+    let slides = extract_slides(path).map_err(|e| to_parse_error("PowerPoint", &e))?;
+    if slides.is_empty() {
+        tracing::warn!("PPTX(COM) file has no text content: {:?}", path);
+    }
+    let mut all_text = String::new();
+    let mut chunks = Vec::new();
+    let mut global_offset = 0;
+
+    for slide in &slides {
+        if !all_text.is_empty() {
+            all_text.push('\n');
+            global_offset += 1;
+        }
+
+        let slide_chunks = chunk_slide(
+            &slide.text,
+            slide.slide_number,
+            global_offset,
+            DEFAULT_CHUNK_SIZE,
+            DEFAULT_CHUNK_OVERLAP,
+        );
+
+        all_text.push_str(&slide.text);
+        global_offset += slide.text.chars().count();
+        chunks.extend(slide_chunks);
+    }
+
+    Ok(ParsedDocument {
+        content: all_text,
+        metadata: DocumentMetadata {
+            title: path.file_stem().and_then(|s| s.to_str()).map(String::from),
+            author: None,
+            created_at: None,
+            page_count: if slides.len() > 1 {
+                Some(slides.len())
+            } else {
+                None
+            },
+        },
+        chunks,
+        garbled_hint: false,
+    })
+}
+
+/// 슬라이드별 텍스트 정보 (슬라이드 번호 + 정규화된 텍스트).
+struct SlideText {
+    slide_number: usize,
+    text: String,
+}
+
+/// PowerPoint 를 COM 자동화로 구동해 각 슬라이드의 텍스트를 추출.
+///
+/// Application → `Presentations.Open` → `Slides` 컬렉션 순회 →
+/// 각 슬라이드의 Shape 텍스트 + `NotesPage` 텍스트 수집 순서로 동작.
+fn extract_slides(path: &Path) -> windows::core::Result<Vec<SlideText>> {
+    let app = Obj::create("PowerPoint.Application")?;
+    let _guard = AppGuard::new(&app);
+    // PowerPoint 는 Word/Excel 과 달리 Visible=false 미지원 — 항상 가시 창으로 동작.
+    let _ = app.put("DisplayAlerts", var_i32(PP_ALERTS_NONE));
+    let _ = app.put(
+        "AutomationSecurity",
+        var_i32(super::MSO_AUTOMATION_SECURITY_FORCE_DISABLE),
+    );
+
+    let presentations = app.get_obj("Presentations", &[])?;
+    let path_str = super::path_arg(path);
+    let pres_var = presentations.call(
+        "Open",
+        &[
+            var_str(&path_str), // FileName — 절대 경로
+            var_i32(MSO_TRUE),  // ReadOnly — 읽기 전용
+            var_i32(MSO_FALSE), // Untitled — 새 제목 부여 안 함
+            var_i32(MSO_FALSE), // WithWindow — PowerPoint 창 표시 안 함
+        ],
+    )?;
+    let pres = super::as_obj(&pres_var)?;
+
+    let slides_col = pres.get_obj("Slides", &[])?;
+    let count = slides_col.get_i32("Count", &[]);
+
+    let mut out: Vec<SlideText> = Vec::new();
+    for i in 1..=count {
+        let slide = match slides_col.get_obj("Item", &[var_i32(i)]) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let mut slide_text = collect_shape_text(&slide);
+        // 노트 페이지(발표자 메모) 텍스트 추가 — "[노트]" prefix 로 본문과 구분.
+        if let Ok(notes_page) = slide.get_obj("NotesPage", &[]) {
+            let note = collect_shape_text(&notes_page);
+            if !note.is_empty() {
+                if !slide_text.is_empty() {
+                    slide_text.push('\n');
+                }
+                slide_text.push_str("[노트] ");
+                slide_text.push_str(&note);
+            }
+        }
+        if !slide_text.is_empty() {
+            out.push(SlideText {
+                slide_number: i as usize,
+                text: slide_text,
+            });
+        }
+    }
+
+    let _ = pres.call("Close", &[]);
+
+    Ok(out)
+}
+
+/// 컨테이너(슬라이드 또는 노트 페이지) 내 모든 Shape 의 텍스트를 수집.
+///
+/// 각 Shape → `HasTextFrame` → `TextFrame.HasText` → `TextRange.Text` 순서로
+/// 텍스트를 안전하게 추출한다 (텍스트가 없는 도형/이미지는 건너뜀).
+fn collect_shape_text(container: &Obj) -> String {
+    let shapes = match container.get_obj("Shapes", &[]) {
+        Ok(s) => s,
+        Err(_) => return String::new(),
+    };
+    let count = shapes.get_i32("Count", &[]);
+    let mut parts: Vec<String> = Vec::new();
+    for j in 1..=count {
+        let shape = match shapes.get_obj("Item", &[var_i32(j)]) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        if shape.get_i32("HasTextFrame", &[]) != MSO_TRUE {
+            continue;
+        }
+        let text_frame = match shape.get_obj("TextFrame", &[]) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if text_frame.get_i32("HasText", &[]) != MSO_TRUE {
+            continue;
+        }
+        let text_range = match text_frame.get_obj("TextRange", &[]) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let raw = match text_range.get("Text", &[]) {
+            Ok(v) => v_string(&v),
+            Err(_) => continue,
+        };
+        let normalized = normalize_lines(&raw);
+        if !normalized.is_empty() {
+            parts.push(normalized);
+        }
+    }
+
+    parts.join("\n")
+}
+
+/// 줄바꿈 정규화 — CR/LF/수직탭을 `\n`으로 통일하고 빈 줄을 제거한다.
+fn normalize_lines(text: &str) -> String {
+    text.split(['\r', '\n', '\u{000B}'])
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// 슬라이드 텍스트를 청크로 분할 (슬라이드 번호·위치 힌트 유지).
+/// `global_offset` 은 전체 문서 기준 오프셋 (start_offset/end_offset 에 사용).
+fn chunk_slide(
+    text: &str,
+    slide_number: usize,
+    global_offset: usize,
+    chunk_size: usize,
+    overlap: usize,
+) -> Vec<DocumentChunk> {
+    let mut chunks = Vec::new();
+    let chars: Vec<char> = text.chars().collect();
+    let total_len = chars.len();
+
+    if total_len == 0 {
+        return chunks;
+    }
+
+    let step = chunk_size.saturating_sub(overlap).max(1);
+    let mut start = 0;
+
+    while start < total_len {
+        let end = (start + chunk_size).min(total_len);
+        let chunk_content: String = chars[start..end].iter().collect();
+
+        chunks.push(DocumentChunk {
+            content: chunk_content,
+            start_offset: global_offset + start,
+            end_offset: global_offset + end,
+            page_number: Some(slide_number),
+            page_end: Some(slide_number),
+            location_hint: Some(format!("슬라이드 {}", slide_number)),
+        });
+
+        start += step;
+
+        if end >= total_len {
+            break;
+        }
+    }
+
+    chunks
+}

--- a/src-tauri/src/parsers/wincom/pptx.rs
+++ b/src-tauri/src/parsers/wincom/pptx.rs
@@ -7,7 +7,8 @@
 use std::path::Path;
 
 use super::{
-    to_parse_error, v_string, var_i32, var_str, AppGuard, AppKind, ComApartment, Obj, MSO_FALSE, MSO_TRUE,
+    to_parse_error, v_string, var_i32, var_str, AppGuard, AppKind, ComApartment, Obj, MSO_FALSE,
+    MSO_TRUE,
 };
 use crate::parsers::{
     DocumentChunk, DocumentMetadata, ParseError, ParsedDocument, DEFAULT_CHUNK_OVERLAP,

--- a/src-tauri/src/parsers/wincom/pptx.rs
+++ b/src-tauri/src/parsers/wincom/pptx.rs
@@ -93,6 +93,8 @@ struct SlideText {
 fn extract_slides(path: &Path) -> windows::core::Result<Vec<SlideText>> {
     let app = Obj::create("PowerPoint.Application")?;
     let _guard = AppGuard::new(&app, AppKind::PowerPoint);
+    let original_display_alerts = app.get("DisplayAlerts", &[])?;
+    let original_automation_security = app.get("AutomationSecurity", &[])?;
     // PowerPoint 는 Word/Excel 과 달리 Visible=false 미지원 — 항상 가시 창으로 동작.
     let _ = app.put("DisplayAlerts", var_i32(PP_ALERTS_NONE));
     let _ = app.put(
@@ -111,6 +113,7 @@ fn extract_slides(path: &Path) -> windows::core::Result<Vec<SlideText>> {
             var_i32(MSO_FALSE), // WithWindow — PowerPoint 창 표시 안 함
         ],
     )?;
+    let _ = app.put("AutomationSecurity", original_automation_security);
     let pres = super::as_obj(&pres_var)?;
 
     let slides_col = pres.get_obj("Slides", &[])?;
@@ -143,6 +146,7 @@ fn extract_slides(path: &Path) -> windows::core::Result<Vec<SlideText>> {
     }
 
     let _ = pres.call("Close", &[]);
+    let _ = app.put("DisplayAlerts", original_display_alerts);
 
     Ok(out)
 }

--- a/src-tauri/src/parsers/wincom/pptx.rs
+++ b/src-tauri/src/parsers/wincom/pptx.rs
@@ -7,7 +7,7 @@
 use std::path::Path;
 
 use super::{
-    to_parse_error, v_string, var_i32, var_str, AppGuard, ComApartment, Obj, MSO_FALSE, MSO_TRUE,
+    to_parse_error, v_string, var_i32, var_str, AppGuard, AppKind, ComApartment, Obj, MSO_FALSE, MSO_TRUE,
 };
 use crate::parsers::{
     DocumentChunk, DocumentMetadata, ParseError, ParsedDocument, DEFAULT_CHUNK_OVERLAP,
@@ -91,7 +91,7 @@ struct SlideText {
 /// 각 슬라이드의 Shape 텍스트 + `NotesPage` 텍스트 수집 순서로 동작.
 fn extract_slides(path: &Path) -> windows::core::Result<Vec<SlideText>> {
     let app = Obj::create("PowerPoint.Application")?;
-    let _guard = AppGuard::new(&app);
+    let _guard = AppGuard::new(&app, AppKind::PowerPoint);
     // PowerPoint 는 Word/Excel 과 달리 Visible=false 미지원 — 항상 가시 창으로 동작.
     let _ = app.put("DisplayAlerts", var_i32(PP_ALERTS_NONE));
     let _ = app.put(

--- a/src-tauri/src/parsers/wincom/xlsx.rs
+++ b/src-tauri/src/parsers/wincom/xlsx.rs
@@ -1,0 +1,426 @@
+//! Windows COM(Excel.Application) 기반 XLS/XLSX 파서 — Windows 전용.
+//!
+//! `parsers::xlsx` (Rust ZIP/calamine 파서) 실패 시 `wincom_fallback_xlsx` 에서 호출.
+//! 설치된 Excel 로 워크북을 열어 각 시트의 `UsedRange` 에서 셀 값을 추출한다.
+//! 레거시 .xls (BIFF) 포맷도 Excel 이 직접 처리하므로 Rust 파서가 지원하지 못하는
+//! 포맷의 fallback 역할을 한다.
+
+use std::ffi::c_void;
+use std::path::Path;
+
+use windows::Win32::System::Com::SAFEARRAY;
+use windows::Win32::System::Ole::{
+    SafeArrayGetDim, SafeArrayGetElement, SafeArrayGetLBound, SafeArrayGetUBound,
+};
+use windows::Win32::System::Variant::{VARIANT, VT_BOOL, VT_BSTR, VT_R8};
+
+use super::{
+    to_parse_error, v_is_array, v_is_empty, v_string, v_to_display_string, var_bool, var_i32,
+    var_str, AppGuard, ComApartment, Obj,
+};
+use crate::parsers::{
+    DocumentChunk, DocumentMetadata, ParseError, ParsedDocument, DEFAULT_CHUNK_OVERLAP,
+    DEFAULT_CHUNK_SIZE,
+};
+
+/// 로컬 파일 크기 상한 (100MB) — 전역 `MAX_FILE_SIZE` 와 별도로 운영.
+/// .xls(OLE 복합 문서) 포맷은 압축이 없어 OOXML 보다 클 수 있어 여유를 둔다.
+const MAX_FILE_SIZE: u64 = 100 * 1024 * 1024;
+/// 시트당 최대 추출 행 수 (OOM 방지).
+const MAX_ROWS_PER_SHEET: usize = 50_000;
+/// 전체 추출 문자 수 상한 (OOM 방지).
+const MAX_TOTAL_CHARS: usize = 5_000_000;
+
+/// XLS/XLSX 파일을 COM(Excel.Application) 으로 파싱.
+///
+/// `parse_with_timeout` 래퍼를 통해 별도 STA 스레드에서 실행되며,
+/// 타임아웃·패닉 방어가 적용된다.
+pub fn parse(path: &Path) -> Result<ParsedDocument, ParseError> {
+    let _bc = crate::breadcrumb::Guard::new(path, "parse_xlsx_com");
+
+    // 파일 크기 체크 (대용량 파일 메모리 보호)
+    if let Ok(metadata) = std::fs::metadata(path) {
+        if metadata.len() > MAX_FILE_SIZE {
+            return Err(ParseError::ParseError(format!(
+                "XLS/XLSX 파일 크기 초과: {}MB (최대 {}MB)",
+                metadata.len() / 1024 / 1024,
+                MAX_FILE_SIZE / 1024 / 1024
+            )));
+        }
+    }
+
+    let _com = ComApartment::init();
+
+    let sheets = extract_sheets(path).map_err(|e| to_parse_error("Excel", &e))?;
+
+    let mut all_text = String::new();
+    let mut chunks = Vec::new();
+    let mut global_offset = 0;
+    let mut sheets_extracted: usize = 0;
+
+    for sheet in &sheets {
+        // 전체 문자 수 상한 도달 시 남은 시트 건너뜀 (OOM 방지).
+        if all_text.len() > MAX_TOTAL_CHARS {
+            tracing::warn!(
+                "XLSX(COM) truncated at {} chars (max {}), remaining sheets skipped",
+                all_text.len(),
+                MAX_TOTAL_CHARS
+            );
+            break;
+        }
+
+        let (sheet_text, sheet_chunks) = build_sheet(&sheet.name, &sheet.rows, global_offset);
+
+        if !sheet_text.is_empty() {
+            sheets_extracted += 1;
+            if !all_text.is_empty() {
+                all_text.push_str("\n\n");
+                global_offset += 2;
+            }
+            // 시트명 헤더 — 시트 경계를 텍스트에 표시.
+            let header = format!("[{}]\n", sheet.name);
+            all_text.push_str(&header);
+            global_offset += header.len();
+
+            all_text.push_str(&sheet_text);
+            global_offset += sheet_text.len();
+
+            chunks.extend(sheet_chunks);
+        }
+    }
+
+    tracing::info!(
+        "XLSX(COM) done: {} (sheets extracted: {}, {} chunks, {} chars)",
+        path.display(),
+        sheets_extracted,
+        chunks.len(),
+        all_text.len()
+    );
+
+    if all_text.is_empty() {
+        tracing::warn!("XLSX(COM) file has no text content: {:?}", path);
+    }
+
+    Ok(ParsedDocument {
+        content: all_text,
+        metadata: DocumentMetadata {
+            title: path.file_stem().and_then(|s| s.to_str()).map(String::from),
+            author: None,
+            created_at: None,
+            page_count: None,
+        },
+        chunks,
+        garbled_hint: false,
+    })
+}
+
+/// 시트별 추출 데이터 (시트명 + (행 번호, 탭 구분 행 텍스트) 목록).
+struct SheetData {
+    name: String,
+    rows: Vec<(usize, String)>,
+}
+
+/// Excel 을 COM 자동화로 구동해 각 시트의 `UsedRange` 에서 셀 값을 추출.
+///
+/// Application → `Workbooks.Open` → `Worksheets` 컬렉션 순회 →
+/// 각 시트의 `UsedRange.Value` (2차원 SAFEARRAY) 를 행별 문자열로 변환.
+fn extract_sheets(path: &Path) -> windows::core::Result<Vec<SheetData>> {
+    let app = Obj::create("Excel.Application")?;
+    let _guard = AppGuard::new(&app);
+    // Excel 을 백그라운드로 실행 — 경고·이벤트·링크 갱신·매크로 모두 차단.
+    let _ = app.put("Visible", var_bool(false));
+    let _ = app.put("DisplayAlerts", var_bool(false));
+    let _ = app.put("ScreenUpdating", var_bool(false));
+    let _ = app.put("EnableEvents", var_bool(false));
+    let _ = app.put("AskToUpdateLinks", var_bool(false));
+    let _ = app.put(
+        "AutomationSecurity",
+        var_i32(super::MSO_AUTOMATION_SECURITY_FORCE_DISABLE),
+    );
+
+    let workbooks = app.get_obj("Workbooks", &[])?;
+    let path_str = super::path_arg(path);
+    let wb_var = workbooks.call(
+        "Open",
+        &[
+            var_str(&path_str),             // FileName — 절대 경로
+            var_i32(0),                     // UpdateLinks — 외부 링크 갱신 안 함
+            var_bool(true),                 // ReadOnly — 읽기 전용
+            super::missing_arg(),           // Format — 생략 (기본 형식 자동 감지)
+            var_str(super::BOGUS_PASSWORD), // Password — 가짜 암호 (보호 문서 즉시 실패)
+        ],
+    )?;
+    let wb = super::as_obj(&wb_var)?;
+
+    let worksheets = wb.get_obj("Worksheets", &[])?;
+    let count = worksheets.get_i32("Count", &[]);
+
+    let mut out: Vec<SheetData> = Vec::new();
+    for i in 1..=count {
+        let sheet = match worksheets.get_obj("Item", &[var_i32(i)]) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let name = sheet.get_string("Name", &[]);
+
+        // UsedRange — 데이터가 있는 범위만 추출 (빈 시트 제외).
+        let used = match sheet.get_obj("UsedRange", &[]) {
+            Ok(u) => u,
+            Err(_) => continue,
+        };
+        let first_row = used.get_i32("Row", &[]).max(1) as usize;
+
+        // UsedRange.Value — 2차원 SAFEARRAY (행 × 열). 단일 셀인 경우 스칼라 VARIANT.
+        let value = match used.get("Value", &[]) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let rows = read_used_range(&value, first_row);
+        out.push(SheetData { name, rows });
+    }
+
+    let _ = wb.call("Close", &[var_bool(false)]);
+
+    Ok(out)
+}
+
+/// `UsedRange.Value` (SAFEARRAY 또는 스칼라) 를 행별 문자열로 변환.
+///
+/// 2차원 SAFEARRAY 의 경우 각 셀을 `cell_to_string` 으로 변환하여
+/// 탭(`\t`) 구분 행 텍스트를 생성. 단일 셀(스칼라)은 1행으로 처리.
+/// `MAX_ROWS_PER_SHEET` · `MAX_TOTAL_CHARS` 상한으로 OOM 을 방지한다.
+fn read_used_range(value: &VARIANT, first_row: usize) -> Vec<(usize, String)> {
+    let mut rows: Vec<(usize, String)> = Vec::new();
+    let mut total_chars = 0usize;
+
+    if v_is_array(value) {
+        let psa: *const SAFEARRAY =
+            unsafe { value.Anonymous.Anonymous.Anonymous.parray } as *const SAFEARRAY;
+        if psa.is_null() {
+            return rows;
+        }
+
+        // 2차원 배열(행×열)만 처리 — 1차원이면 스킵.
+        if unsafe { SafeArrayGetDim(psa) } != 2 {
+            return rows;
+        }
+        let (r_lb, r_ub) = match (unsafe { SafeArrayGetLBound(psa, 1) }, unsafe {
+            SafeArrayGetUBound(psa, 1)
+        }) {
+            (Ok(a), Ok(b)) => (a, b),
+            _ => return rows,
+        };
+        let (c_lb, c_ub) = match (unsafe { SafeArrayGetLBound(psa, 2) }, unsafe {
+            SafeArrayGetUBound(psa, 2)
+        }) {
+            (Ok(a), Ok(b)) => (a, b),
+            _ => return rows,
+        };
+        for (row_idx, r) in (r_lb..=r_ub).enumerate() {
+            if row_idx >= MAX_ROWS_PER_SHEET {
+                tracing::warn!(
+                    "XLSX(COM) sheet truncated at {} rows (max {})",
+                    row_idx,
+                    MAX_ROWS_PER_SHEET
+                );
+                break;
+            }
+            let actual_row = first_row + row_idx;
+
+            let mut cells: Vec<String> = Vec::new();
+            for c in c_lb..=c_ub {
+                let indices = [r, c];
+                let mut elem = VARIANT::default();
+                let hr = unsafe {
+                    SafeArrayGetElement(
+                        psa,
+                        indices.as_ptr(),
+                        &mut elem as *mut VARIANT as *mut c_void,
+                    )
+                };
+                if hr.is_ok() {
+                    if let Some(s) = cell_to_string(&elem) {
+                        cells.push(s);
+                    }
+                }
+            }
+            if !cells.is_empty() {
+                let row_text = cells.join("\t");
+                total_chars += row_text.len();
+                if total_chars > MAX_TOTAL_CHARS {
+                    tracing::warn!(
+                        "XLSX(COM) sheet truncated at {} chars (max {})",
+                        total_chars,
+                        MAX_TOTAL_CHARS
+                    );
+                    break;
+                }
+                rows.push((actual_row, row_text));
+            }
+        }
+    } else if !v_is_empty(value) {
+        // 단일 셀 — UsedRange 가 1×1 인 경우 Value 가 SAFEARRAY 가 아닌 스칼라.
+        if let Some(s) = cell_to_string(value) {
+            rows.push((first_row, s));
+        }
+    }
+
+    rows
+}
+
+/// VARIANT 셀 값을 문자열로 변환.
+///
+/// - `VT_BSTR`: 문자열 (trim 후 빈 문자열이면 `None`)
+/// - `VT_BOOL`: `"true"` / `"false"`
+/// - `VT_R8`: 숫자 (정수면 `i64`, 소수면 소수점 2자리)
+/// - 그 외: `v_to_display_string` 으로 로케일 문자열 변환 (날짜·통화 등)
+fn cell_to_string(v: &VARIANT) -> Option<String> {
+    if v_is_empty(v) {
+        return None;
+    }
+    let vt = v.vt();
+    if vt == VT_BSTR {
+        let s = v_string(v);
+        let t = s.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_string())
+        }
+    } else if vt == VT_BOOL {
+        Some(bool::try_from(v).unwrap_or(false).to_string())
+    } else if vt == VT_R8 {
+        let f = f64::try_from(v).unwrap_or(0.0);
+        Some(format_number(f))
+    } else {
+        let s = v_to_display_string(v);
+        let t = s.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_string())
+        }
+    }
+}
+
+/// 숫자 포맷팅 — 정수면 `i64` 로, 소수면 소수점 2자리로 변환.
+fn format_number(f: f64) -> String {
+    if f.fract() == 0.0 && f.abs() < 1e15 {
+        format!("{}", f as i64)
+    } else {
+        format!("{:.2}", f)
+    }
+}
+
+/// 시트 데이터를 전체 텍스트와 청크로 분할.
+/// 행들을 `\n` 으로 연결해 전체 텍스트를 만들고, 행 경계를 유지하며 청크를 생성한다.
+fn build_sheet(
+    sheet_name: &str,
+    row_infos: &[(usize, String)],
+    base_offset: usize,
+) -> (String, Vec<DocumentChunk>) {
+    let full_text = row_infos
+        .iter()
+        .map(|(_, t)| t.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let chunks = create_chunks_with_rows(
+        row_infos,
+        sheet_name,
+        base_offset,
+        DEFAULT_CHUNK_SIZE,
+        DEFAULT_CHUNK_OVERLAP,
+    );
+
+    (full_text, chunks)
+}
+
+/// 행 경계를 유지하며 청크 분할.
+///
+/// `chunk_size` 를 초과하지 않도록 행 단위로 청크를 묶되, 행 하나가
+/// `chunk_size` 보다 크면 그 행을 단독 청크로 만든다. `overlap` 만큼
+/// 이전 청크의 끝 행들을 다음 청크의 시작에 포함시킨다.
+/// 각 청크에는 `location_hint` 로 시트명+행 범위를 기록한다.
+fn create_chunks_with_rows(
+    row_infos: &[(usize, String)],
+    sheet_name: &str,
+    base_offset: usize,
+    chunk_size: usize,
+    overlap: usize,
+) -> Vec<DocumentChunk> {
+    let mut chunks = Vec::new();
+    let n = row_infos.len();
+    if n == 0 {
+        return chunks;
+    }
+
+    let mut start_idx = 0;
+    let mut current_offset = base_offset;
+    while start_idx < n {
+        let mut end_idx = start_idx;
+        let mut current_size = 0;
+
+        // chunk_size 를 채울 때까지 행 추가 (단일 행이 chunk_size 초과면 그 행만).
+        while end_idx < n {
+            let row_size = row_infos[end_idx].1.len() + if end_idx > start_idx { 1 } else { 0 };
+            if current_size + row_size > chunk_size && end_idx > start_idx {
+                break;
+            }
+            current_size += row_size;
+            end_idx += 1;
+        }
+
+        if end_idx == start_idx {
+            end_idx = start_idx + 1;
+        }
+
+        let content: String = row_infos[start_idx..end_idx]
+            .iter()
+            .map(|(_, text)| text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let start_row = row_infos[start_idx].0;
+        let end_row = row_infos[end_idx - 1].0;
+
+        chunks.push(DocumentChunk {
+            content: content.clone(),
+            start_offset: current_offset,
+            end_offset: current_offset + content.len(),
+            page_number: None,
+            page_end: None,
+            location_hint: Some(format_location_hint(sheet_name, start_row, end_row)),
+        });
+
+        current_offset += content.len() + 1;
+
+        // overlap 만큼 이전 행들을 다음 청크에 포함.
+        if overlap == 0 {
+            start_idx = end_idx;
+        } else {
+            let mut overlap_size = 0;
+            let mut new_start = end_idx;
+            for idx in (start_idx..end_idx).rev() {
+                let row_size = row_infos[idx].1.len() + 1;
+                if overlap_size + row_size > overlap && new_start < end_idx {
+                    break;
+                }
+                overlap_size += row_size;
+                new_start = idx;
+            }
+            start_idx = new_start.max(start_idx + 1);
+        }
+    }
+
+    chunks
+}
+
+/// 위치 힌트 문자열 생성 (예: `"Sheet1!행3"` 또는 `"Sheet1!행3-10"`).
+fn format_location_hint(sheet_name: &str, start_row: usize, end_row: usize) -> String {
+    if start_row == end_row {
+        format!("{}!행{}", sheet_name, start_row)
+    } else {
+        format!("{}!행{}-{}", sheet_name, start_row, end_row)
+    }
+}

--- a/src-tauri/src/parsers/wincom/xlsx.rs
+++ b/src-tauri/src/parsers/wincom/xlsx.rs
@@ -16,7 +16,7 @@ use windows::Win32::System::Variant::{VARIANT, VT_BOOL, VT_BSTR, VT_R8};
 
 use super::{
     to_parse_error, v_is_array, v_is_empty, v_string, v_to_display_string, var_bool, var_i32,
-    var_str, AppGuard, ComApartment, Obj,
+    var_str, AppGuard, AppKind, ComApartment, Obj,
 };
 use crate::parsers::{
     DocumentChunk, DocumentMetadata, ParseError, ParsedDocument, DEFAULT_CHUNK_OVERLAP,
@@ -126,7 +126,7 @@ struct SheetData {
 /// 각 시트의 `UsedRange.Value` (2차원 SAFEARRAY) 를 행별 문자열로 변환.
 fn extract_sheets(path: &Path) -> windows::core::Result<Vec<SheetData>> {
     let app = Obj::create("Excel.Application")?;
-    let _guard = AppGuard::new(&app);
+    let _guard = AppGuard::new(&app, AppKind::Excel);
     // Excel 을 백그라운드로 실행 — 경고·이벤트·링크 갱신·매크로 모두 차단.
     let _ = app.put("Visible", var_bool(false));
     let _ = app.put("DisplayAlerts", var_bool(false));

--- a/src/components/settings/tabs/SearchTab.tsx
+++ b/src/components/settings/tabs/SearchTab.tsx
@@ -501,6 +501,37 @@ export function SearchTab({ settings, onChange }: TabProps) {
       </div>
       )}
 
+      {/* Read with MS Office via Windows COM*/}
+      <div className="border-t pt-3" style={{ borderColor: "var(--color-border)" }}>
+        <label
+	  className="flex items-center text-sm font-medium mb-2"
+	  style={{ color: "var(--color-text-secondary)" }}
+	>
+	  설치된 MS 오피스로 파일 읽기
+	</label>
+
+        <SettingsToggle
+          label="설치된 MS Word 로 DOCX 읽기"
+          description="사내 파일암호화 등으로 인덱싱이 되지않을때 최후의 수단"
+          checked={settings.use_wincom_for_docx ?? false}
+          onChange={(v) => onChange("use_wincom_for_docx", v)}
+        />
+
+        <SettingsToggle
+          label="설치된 MS Excel 로 XLSX, XLS 읽기"
+          description="사내 파일암호화 등으로 인덱싱이 되지않을때 최후의 수단"
+          checked={settings.use_wincom_for_xlsx ?? false}
+          onChange={(v) => onChange("use_wincom_for_xlsx", v)}
+        />
+
+        <SettingsToggle
+          label="설치된 MS PowerPoint 로 PPTX 읽기"
+          description="사내 파일암호화 등으로 인덱싱이 되지않을때 최후의 수단"
+          checked={settings.use_wincom_for_pptx ?? false}
+          onChange={(v) => onChange("use_wincom_for_pptx", v)}
+        />
+      </div>
+
       {/* 문서 버전 그룹핑 (Document Lineage) */}
       <div>
         <SettingsToggle

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -96,4 +96,7 @@ export interface Settings {
    * false면 상대시간("3일 전")을 표시하고 절대 날짜/시간은 툴팁으로 노출.
    */
   show_absolute_time: boolean;
+  use_wincom_for_docx?: boolean,
+  use_wincom_for_xlsx?: boolean,
+  use_wincom_for_pptx?: boolean,
 }


### PR DESCRIPTION
## 동기

저희 회사처럼 자체 보안 솔루션으로 문서를 암호화하는 회사 등에서 Docufinder 를 사용하는 경우 kordoc 사용 또는 OOXML 에 직접 접근하는 방법이 불가능합니다 (보안 솔루션이 프로그램별로 파일 복호화 여부를 제어, 회사 공식 허가한 프로그램 외에는 깨진 파일로 인식). 이 경우 최소한 회사에서 공식 프로그램 (MS Office) 으로는 문서를 열 수 있는고, MS Office 프로그램은 Windows COM (Component Object Model) 을 사용하여 직접 제어, 문서를 열고 읽을 수 있다는 점에 착안하여 kordoc, OOXML 사용 실패시 최후의 수단으로 프로그램으로 직접 읽어서 인덱싱을 하고자 했습니다.

## 변경사항

- 설정창 검색탭에 워드, 엑셀, 파워포인트 각각 MS Office 로 인덱싱하는 옵션 추가
- parsers/mod.rs 에서 워드, 엑셀, 파워포인트 각각 kordoc, OOXML 로 인덱싱 실패시 MS Office 로 인덱싱하는 fallback 로직 추가
- parsers/wincom/ 추가
  - mod.rs: Windows COM 으로 MS Word, PowerPoint, Excel 직접 제어에 필요한 기본 boilerplate, 유틸리티
  - {docx, pptx, xlsx}.rs: MS Word, PowerPoint, Excel 직접 제어로 텍스트 추출, chunking
- MS Word, PowerPoint, Excel 직접제어이지만, 인덱싱 할 때에 프로그램이 화면에 나타나서 사용자의 시야나 작업을 방해하지 않습니다.

## 기타의견

- 설정을 별도의 탭으로 분리할 지는 의견주시면 좋을 것 같습니다. 검색 탭에 항목이 많아지고, 이 옵션이 일반적인, 대중적으로 사용될 옵션이 아닐 수도 있어서 '실험실' 탭임나 뭐 그런걸로...